### PR TITLE
Add configurable TX send calibration

### DIFF
--- a/.github/fixtures/debug/ci.yaml
+++ b/.github/fixtures/debug/ci.yaml
@@ -40,6 +40,7 @@ daikin_ekhhe:
   - id: daikin_component
     update_interval: 10
     mode: debug
+    tx_send_calibration: 75
 
 sensor:
   - platform: daikin_ekhhe
@@ -57,6 +58,8 @@ number:
   - platform: daikin_ekhhe
     low_water_hp_hysteris:
       name: "CI Debug Lower water temp hysteresis"
+    tx_send_calibration:
+      name: "CI TX Send Calibration"
 
 select:
   - platform: daikin_ekhhe

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Other than this, the only customization available for the module is:
 * update_interval
 * mode (production or debug)
 * continuous_rx (debug only)
+* tx_send_calibration
 
 `update_interval` sets the normal polling interval in seconds when the component is idle.
 
@@ -25,6 +26,11 @@ Other than this, the only customization available for the module is:
 `continuous_rx: true` is an additional debug-only option that keeps RX running continuously after each parsed cycle for
 reverse engineering. By default it is `false`, so even in debug mode `update_interval` is respected unless a write is
 in flight.
+
+`tx_send_calibration` adjusts the delay, in milliseconds, used when sending write packets on the bus. The default is
+`75`. Most users should not need to change it, but it can help tune write reliability on units with slightly different
+bus timing. The optional `tx_send_calibration` number entity can be enabled while testing; changes apply immediately
+but are not persisted unless the value is also written into YAML.
 
 ## Debug / Reverse Engineering
 There is a debug mode that enables internal raw UART capture and optional Home Assistant entities for inspection. These

--- a/components/daikin_ekhhe/__init__.py
+++ b/components/daikin_ekhhe/__init__.py
@@ -8,6 +8,7 @@ from esphome.const import (
 CONF_UPDATE_INTERVAL = "update_interval"
 CONF_MODE = "mode"
 CONF_CONTINUOUS_RX = "continuous_rx"
+CONF_TX_SEND_CALIBRATION = "tx_send_calibration"
 DEBUG_COMPONENTS = set()
 
 CODEOWNERS = ["@jcappaert"]
@@ -27,6 +28,7 @@ CONFIG_SCHEMA = (
             cv.Optional(CONF_UPDATE_INTERVAL, default=10): cv.positive_int,
             cv.Optional(CONF_MODE, default="production"): cv.one_of("production", "debug", lower=True),
             cv.Optional(CONF_CONTINUOUS_RX, default=False): cv.boolean,
+            cv.Optional(CONF_TX_SEND_CALIBRATION, default=75): cv.int_range(min=0, max=250),
         }
     )
     .extend(uart.UART_DEVICE_SCHEMA)
@@ -40,6 +42,7 @@ async def to_code(config):
 
     update_interval_ms = config[CONF_UPDATE_INTERVAL] * 1000 
     cg.add(var.set_update_interval(update_interval_ms))
+    cg.add(var.set_tx_delay_after_d2_ms(config[CONF_TX_SEND_CALIBRATION]))
     debug_mode = config[CONF_MODE] == "debug"
     cg.add(var.set_continuous_rx(debug_mode and config[CONF_CONTINUOUS_RX]))
     cg.add_build_flag(f"-DDAIKIN_EKHHE_DEBUG={1 if debug_mode else 0}")

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -94,6 +94,7 @@ DAIKIN_DD_B5_TEXT = "dd_b5_text_sensor"
 DD_HEATING_DEMAND = "dd_heating_demand"
 HP_ACTIVE = "hp_active"
 EH_ACTIVE = "eh_active"
+TX_SEND_CALIBRATION = "tx_send_calibration"
 
 FRAMES_CAPTURED_TOTAL = "frames_captured_total"
 FRAMES_DROPPED_TOTAL = "frames_dropped_total"

--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -5,6 +5,7 @@
 
 #include <cinttypes>
 #include <cstdio>
+#include <algorithm>
 #include <numeric>
 #include <ctime>
 #include <cmath>
@@ -1061,7 +1062,8 @@ void DaikinEkhheComponent::schedule_queued_tx_from_d2_(const RawFrameEntry &d2_e
 
   const uint32_t now_ms = millis();
   const uint32_t d2_age_ms = now_ms - d2_entry.timestamp_ms;
-  const uint32_t delay_ms = d2_age_ms >= kTxDelayAfterD2Ms ? 0 : (kTxDelayAfterD2Ms - d2_age_ms);
+  const uint32_t delay_ms =
+      d2_age_ms >= tx_delay_after_d2_ms_ ? 0 : (tx_delay_after_d2_ms_ - d2_age_ms);
   const uint32_t generation = queued_tx_.generation;
 
   queued_tx_.active = true;
@@ -1112,7 +1114,8 @@ void DaikinEkhheComponent::schedule_queued_restore_from_d2_(const RawFrameEntry 
 
   const uint32_t now_ms = millis();
   const uint32_t d2_age_ms = now_ms - d2_entry.timestamp_ms;
-  const uint32_t delay_ms = d2_age_ms >= kTxDelayAfterD2Ms ? 0 : (kTxDelayAfterD2Ms - d2_age_ms);
+  const uint32_t delay_ms =
+      d2_age_ms >= tx_delay_after_d2_ms_ ? 0 : (tx_delay_after_d2_ms_ - d2_age_ms);
   const uint32_t generation = queued_restore_.generation;
 
   queued_restore_.active = true;
@@ -1159,7 +1162,8 @@ void DaikinEkhheComponent::schedule_queued_profile_restore_from_d2_(const RawFra
 
   const uint32_t now_ms = millis();
   const uint32_t d2_age_ms = now_ms - d2_entry.timestamp_ms;
-  const uint32_t delay_ms = d2_age_ms >= kTxDelayAfterD2Ms ? 0 : (kTxDelayAfterD2Ms - d2_age_ms);
+  const uint32_t delay_ms =
+      d2_age_ms >= tx_delay_after_d2_ms_ ? 0 : (tx_delay_after_d2_ms_ - d2_age_ms);
   const uint32_t generation = queued_profile_restore_.generation;
 
   queued_profile_restore_.active = true;
@@ -1969,7 +1973,7 @@ void DaikinEkhheComponent::restore_profile_(bool known_good) {
   const RawFrameEntry *d2_entry = find_latest_frame_by_type_(D2_PACKET_START_BYTE, d2_index, true);
   if (d2_entry != nullptr) {
     uint32_t d2_age_ms = millis() - d2_entry->timestamp_ms;
-    if (d2_age_ms <= kTxDelayAfterD2Ms) {
+    if (d2_age_ms <= tx_delay_after_d2_ms_) {
       schedule_queued_profile_restore_from_d2_(*d2_entry);
       return;
     }
@@ -2401,6 +2405,9 @@ void DaikinEkhheComponent::register_binary_sensor(const std::string &sensor_name
 void DaikinEkhheComponent::register_number(const std::string &number_name, esphome::number::Number *number) {
   if (number != nullptr) {
     numbers_[number_name] = number;
+    if (number_name == TX_SEND_CALIBRATION) {
+      number->publish_state(this->tx_delay_after_d2_ms_);
+    }
   }
 }
 
@@ -2587,6 +2594,7 @@ void DaikinEkhheComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "  Update interval: %lu ms", this->update_interval_);
     ESP_LOGCONFIG(TAG, "  Debug mode: %s", YESNO(debug_mode_));
     ESP_LOGCONFIG(TAG, "  Continuous RX: %s", YESNO(this->continuous_rx_));
+    ESP_LOGCONFIG(TAG, "  TX send calibration: %u ms", this->tx_delay_after_d2_ms_);
 
     // Log all enabled sensors
     ESP_LOGCONFIG(TAG, "Enabled Sensors:");
@@ -2639,6 +2647,14 @@ void DaikinEkhheComponent::set_update_interval(int interval_ms) {
 
 void DaikinEkhheComponent::set_continuous_rx(bool enabled) {
     this->continuous_rx_ = enabled;
+}
+
+void DaikinEkhheComponent::set_tx_delay_after_d2_ms(uint32_t delay_ms) {
+    this->tx_delay_after_d2_ms_ = std::min(delay_ms, kMaxTxDelayAfterD2Ms);
+    auto it = numbers_.find(TX_SEND_CALIBRATION);
+    if (it != numbers_.end() && it->second != nullptr) {
+      it->second->publish_state(this->tx_delay_after_d2_ms_);
+    }
 }
 
 void DaikinEkhheComponent::set_debug_packet(const std::string &value) {
@@ -2726,7 +2742,7 @@ void DaikinEkhheComponent::restore_default_settings() {
   const RawFrameEntry *d2_entry = find_latest_frame_by_type_(D2_PACKET_START_BYTE, d2_index, true);
   if (d2_entry != nullptr) {
     uint32_t d2_age_ms = millis() - d2_entry->timestamp_ms;
-    if (d2_age_ms <= kTxDelayAfterD2Ms) {
+    if (d2_age_ms <= tx_delay_after_d2_ms_) {
       schedule_queued_restore_from_d2_(*d2_entry);
       return;
     }
@@ -2778,6 +2794,14 @@ void DaikinEkhheNumber::control(float value) {
 
     // Use get_name() to determine which UART command to send
     auto name = this->internal_id_;
+
+    if (name == TX_SEND_CALIBRATION) {
+        uint32_t delay_ms = value <= 0.0f ? 0 : static_cast<uint32_t>(value);
+        this->parent_->set_tx_delay_after_d2_ms(delay_ms);
+        delay_ms = this->parent_->get_tx_delay_after_d2_ms();
+        ESP_LOGI(TAG, "TX send calibration set to %u ms", delay_ms);
+        return;
+    }
 
     // Get the CC array index from map, send UART command and update UI state
     auto it_u = U_NUMBER_PARAM_INDEX.find(name);
@@ -3449,7 +3473,7 @@ void DaikinEkhheComponent::send_uart_cc_command(uint8_t index, uint8_t value, ui
     const RawFrameEntry *d2_entry = find_latest_frame_by_type_(D2_PACKET_START_BYTE, d2_index, true);
     if (d2_entry != nullptr) {
       uint32_t d2_age_ms = millis() - d2_entry->timestamp_ms;
-      if (d2_age_ms <= kTxDelayAfterD2Ms) {
+      if (d2_age_ms <= tx_delay_after_d2_ms_) {
         schedule_queued_tx_from_d2_(*d2_entry);
         return;
       }

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -124,6 +124,8 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   void on_shutdown();
   void set_update_interval(int interval_ms);
   void set_continuous_rx(bool enabled);
+  void set_tx_delay_after_d2_ms(uint32_t delay_ms);
+  uint32_t get_tx_delay_after_d2_ms() const { return this->tx_delay_after_d2_ms_; }
 
   // Methods to register sensors, binary sensors, and numbers
   void register_sensor(const std::string &sensor_name, esphome::sensor::Sensor *sensor);
@@ -339,7 +341,8 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   static constexpr uint32_t kCdContextLogDelayMs = 4000;
   static constexpr uint8_t kCdContextFramesBefore = 6;
   static constexpr uint8_t kCdContextFramesAfter = 8;
-  static constexpr uint32_t kTxDelayAfterD2Ms = 75;
+  static constexpr uint32_t kDefaultTxDelayAfterD2Ms = 75;
+  static constexpr uint32_t kMaxTxDelayAfterD2Ms = 250;
   static constexpr uint8_t kTxMaxRepeats = 5;
 
   static constexpr uint8_t kPacketMaskDD = 1 << 0;
@@ -654,6 +657,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   // Cycle management
   unsigned long last_process_time_ = 0;
   unsigned long update_interval_ = 10000;
+  uint32_t tx_delay_after_d2_ms_ = kDefaultTxDelayAfterD2Ms;
 };
 
 using namespace daikin_ekhhe;

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -32,6 +32,7 @@ static const std::string ECO_T_TEMPERATURE       = "eco_target_temperature";
 static const std::string BOOST_T_TEMPERATURE     = "boost_target_temperature";
 static const std::string ELECTRIC_T_TEMPERATURE  = "electric_target_temperature";
 static const std::string VAC_DAYS                = "vacation_days";
+static const std::string TX_SEND_CALIBRATION     = "tx_send_calibration";
 
 static const std::string P1_LOW_WAT_PROBE_HYST   = "low_water_hp_hysteris";
 static const std::string P2_HEAT_ON_DELAY        = "elec_heater_switch_on_delay";

--- a/components/daikin_ekhhe/number.py
+++ b/components/daikin_ekhhe/number.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_STEP,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_DEVICE_CLASS,
+    ENTITY_CATEGORY_CONFIG,
 )
 from esphome.const import (
     CONF_ID,
@@ -15,6 +16,7 @@ from esphome.const import (
     UNIT_EMPTY,
     UNIT_CELSIUS,
     UNIT_HOUR,
+    UNIT_MILLISECOND,
     UNIT_SECOND,
     UNIT_PERCENT,
     UNIT_MINUTE,
@@ -87,6 +89,7 @@ TYPES = [
     BOOST_T_TEMPERATURE,
     ELECTRIC_T_TEMPERATURE,
     VAC_DAYS,
+    TX_SEND_CALIBRATION,
 ]
 
 CONFIG_SCHEMA = (
@@ -438,6 +441,16 @@ CONFIG_SCHEMA = (
                 cv.Optional(CONF_STEP, default=1): cv.positive_float,
                 cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_DURATION): cv.string,
                 cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_EMPTY): cv.string,
+            }),
+            cv.Optional(TX_SEND_CALIBRATION): number.number_schema(
+                DaikinEkhheNumber, entity_category=ENTITY_CATEGORY_CONFIG
+            ).extend({
+                cv.GenerateID(): cv.declare_id(DaikinEkhheNumber),
+                cv.Optional(CONF_MAX_VALUE, default=250): cv.float_,
+                cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
+                cv.Optional(CONF_STEP, default=1): cv.positive_float,
+                cv.Optional(CONF_DEVICE_CLASS, default=DEVICE_CLASS_DURATION): cv.string,
+                cv.Optional(CONF_UNIT_OF_MEASUREMENT, default=UNIT_MILLISECOND): cv.string,
             }),
         }
 

--- a/example-debug.yaml
+++ b/example-debug.yaml
@@ -41,6 +41,7 @@ daikin_ekhhe:
   - id: daikin_component
     update_interval: 10
     mode: debug
+    tx_send_calibration: 75
 
 sensor:
   - platform: daikin_ekhhe
@@ -184,6 +185,8 @@ number:
       name: "Boost mode target temperature"
     electric_target_temperature:
       name: "Electric mode target temperature"
+    tx_send_calibration:
+      name: "TX Send Calibration"
 
 select:
   - platform: daikin_ekhhe


### PR DESCRIPTION
## Summary

Adds configurable TX send calibration for units where the fixed write timing is not reliable.

- Adds `tx_send_calibration` as a component YAML option with a default of `75` ms and bounds of `0-250` ms.
- Adds an optional `tx_send_calibration` number entity so timing can be adjusted live from Home Assistant while testing.
- Applies the configured delay to normal writes, default restore writes, and profile restore writes.
- Keeps the calibration number local-only: changing it updates runtime timing and does not send a Daikin CD packet.
- Updates the debug fixture, debug example, and README documentation.

## Validation

- `uv run --with esphome==2026.1.2 esphome config .github/fixtures/production/ci.yaml`
- `uv run --with esphome==2026.1.2 esphome config .github/fixtures/debug/ci.yaml`
- `uv run --with esphome==2026.1.2 esphome compile .github/fixtures/production/ci.yaml`
- `uv run --with esphome==2026.1.2 esphome compile .github/fixtures/debug/ci.yaml`
