### PR TITLE
Defer user TX while awaiting readback

### DIFF
--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -1054,6 +1054,67 @@ void DaikinEkhheComponent::reset_queued_profile_restore_() {
   queued_profile_restore_.anchor_seq = 0;
 }
 
+bool DaikinEkhheComponent::defer_single_field_tx_(uint8_t index, uint8_t value, uint8_t bit_position) {
+  for (auto &deferred : deferred_user_txs_) {
+    if (deferred.index == index && deferred.bit_position == bit_position) {
+      deferred.value = value;
+      ESP_LOGI(TAG, "TX deferred write updated: index=%u value=0x%02X bit=%u queued=%u",
+               index, value, bit_position, static_cast<unsigned>(deferred_user_txs_.size()));
+      return true;
+    }
+  }
+
+  if (deferred_user_txs_.size() >= kDeferredTxMax) {
+    DAIKIN_WARN(TAG, "TX deferred write queue full, dropping write: index=%u value=0x%02X bit=%u",
+                index, value, bit_position);
+    return false;
+  }
+
+  DeferredTx deferred;
+  deferred.index = index;
+  deferred.value = value;
+  deferred.bit_position = bit_position;
+  deferred_user_txs_.push_back(deferred);
+
+  ESP_LOGI(TAG, "TX deferred write queued: index=%u value=0x%02X bit=%u queued=%u",
+           index, value, bit_position, static_cast<unsigned>(deferred_user_txs_.size()));
+
+  if (!uart_active_ && !uart_tx_active_) {
+    start_uart_cycle();
+  }
+
+  return true;
+}
+
+bool DaikinEkhheComponent::has_deferred_user_tx_(uint8_t index, uint8_t bit_position) const {
+  for (const auto &deferred : deferred_user_txs_) {
+    if (deferred.index == index && deferred.bit_position == bit_position) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void DaikinEkhheComponent::flush_deferred_user_tx_() {
+  if (deferred_user_txs_.empty()) {
+    return;
+  }
+  if (pending_tx_.active || queued_tx_.active || queued_tx_.scheduled || tx_ui_sync_.active ||
+      pending_restore_.active || restore_ui_sync_.active ||
+      pending_profile_restore_.active || profile_ui_sync_.active) {
+    return;
+  }
+
+  DeferredTx deferred = deferred_user_txs_.front();
+  deferred_user_txs_.erase(deferred_user_txs_.begin());
+
+  ESP_LOGI(TAG, "TX deferred write starting: index=%u value=0x%02X bit=%u remaining=%u",
+           deferred.index, deferred.value, deferred.bit_position,
+           static_cast<unsigned>(deferred_user_txs_.size()));
+
+  send_uart_cc_command(deferred.index, deferred.value, deferred.bit_position);
+}
+
 void DaikinEkhheComponent::schedule_queued_tx_from_d2_(const RawFrameEntry &d2_entry) {
   if (!pending_tx_.active || queued_tx_.scheduled) {
     return;
@@ -2054,6 +2115,7 @@ void DaikinEkhheComponent::process_packet_set() {
 
   publish_debug_outputs_();
   update_dd_b1_bit_sensors_();
+  flush_deferred_user_tx_();
 
   // Reset UART cycle
   processing_updates_ = false;
@@ -2214,8 +2276,9 @@ void DaikinEkhheComponent::parse_cc_packet(std::vector<uint8_t> buffer) {
   for (const auto &entry : U_NUMBER_PARAM_INDEX) {
     const std::string &param_name = entry.first;
     uint8_t param_index = entry.second;
-    if (pending_tx_.active && pending_tx_.index == param_index &&
-        pending_tx_.bit_position == BIT_POSITION_NO_BITMASK) {
+    if ((pending_tx_.active && pending_tx_.index == param_index &&
+         pending_tx_.bit_position == BIT_POSITION_NO_BITMASK) ||
+        has_deferred_user_tx_(param_index, BIT_POSITION_NO_BITMASK)) {
       continue;
     }
     if (tx_ui_sync_.active && tx_ui_sync_.index == param_index &&
@@ -2237,8 +2300,9 @@ void DaikinEkhheComponent::parse_cc_packet(std::vector<uint8_t> buffer) {
   for (const auto &entry : I_NUMBER_PARAM_INDEX) {
     const std::string &param_name = entry.first;
     uint8_t param_index = entry.second;
-    if (pending_tx_.active && pending_tx_.index == param_index &&
-        pending_tx_.bit_position == BIT_POSITION_NO_BITMASK) {
+    if ((pending_tx_.active && pending_tx_.index == param_index &&
+         pending_tx_.bit_position == BIT_POSITION_NO_BITMASK) ||
+        has_deferred_user_tx_(param_index, BIT_POSITION_NO_BITMASK)) {
       continue;
     }
     if (tx_ui_sync_.active && tx_ui_sync_.index == param_index &&
@@ -2261,8 +2325,9 @@ void DaikinEkhheComponent::parse_cc_packet(std::vector<uint8_t> buffer) {
   for (const auto &entry : SELECT_PARAM_INDEX) {
     const std::string &param_name = entry.first;
     uint8_t param_index = entry.second;
-    if (pending_tx_.active && pending_tx_.index == param_index &&
-        pending_tx_.bit_position == BIT_POSITION_NO_BITMASK) {
+    if ((pending_tx_.active && pending_tx_.index == param_index &&
+         pending_tx_.bit_position == BIT_POSITION_NO_BITMASK) ||
+        has_deferred_user_tx_(param_index, BIT_POSITION_NO_BITMASK)) {
       continue;
     }
     if (tx_ui_sync_.active && tx_ui_sync_.index == param_index &&
@@ -2286,8 +2351,9 @@ void DaikinEkhheComponent::parse_cc_packet(std::vector<uint8_t> buffer) {
     const std::string &param_name = entry.first;
     uint8_t param_index = entry.second.first;  // The byte index
     uint8_t bit_position = entry.second.second;  // The specific bit to extract
-    if (pending_tx_.active && pending_tx_.index == param_index &&
-        pending_tx_.bit_position == bit_position) {
+    if ((pending_tx_.active && pending_tx_.index == param_index &&
+         pending_tx_.bit_position == bit_position) ||
+        has_deferred_user_tx_(param_index, bit_position)) {
       continue;
     }
     if (tx_ui_sync_.active && tx_ui_sync_.index == param_index &&
@@ -3147,6 +3213,7 @@ void DaikinEkhheComponent::check_pending_tx_(const std::vector<uint8_t> &buffer)
     pending_tx_.last_attempt_d2_seq = 0;
     queued_tx_.active = false;
     queued_tx_.scheduled = false;
+    flush_deferred_user_tx_();
     return;
   }
 
@@ -3190,6 +3257,7 @@ void DaikinEkhheComponent::check_pending_tx_(const std::vector<uint8_t> &buffer)
     pending_tx_.last_attempt_d2_seq = 0;
     queued_tx_.active = false;
     queued_tx_.scheduled = false;
+    flush_deferred_user_tx_();
     return;
   }
 
@@ -3247,6 +3315,7 @@ void DaikinEkhheComponent::check_pending_tx_(const std::vector<uint8_t> &buffer)
   tx_ui_sync_.cycles_waited = 0;
   queued_tx_.active = false;
   queued_tx_.scheduled = false;
+  flush_deferred_user_tx_();
 }
 
 void DaikinEkhheComponent::check_pending_restore_(const std::vector<uint8_t> &buffer) {
@@ -3399,6 +3468,10 @@ void DaikinEkhheComponent::send_uart_cc_command(uint8_t index, uint8_t value, ui
     }
     if (pending_profile_restore_.active || profile_ui_sync_.active) {
         DAIKIN_WARN(TAG, "Profile restore in progress, ignoring single-parameter write.");
+        return;
+    }
+    if (pending_tx_.active || queued_tx_.active || queued_tx_.scheduled || tx_ui_sync_.active) {
+        defer_single_field_tx_(index, value, bit_position);
         return;
     }
 

--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -2850,15 +2850,17 @@ void DaikinEkhheNumber::control(float value) {
     auto it_i = I_NUMBER_PARAM_INDEX.find(name);
     if (it_u != U_NUMBER_PARAM_INDEX.end()) {
         uint8_t index = it_u->second;
-        this->parent_->send_uart_cc_command(index, (uint8_t)value, BIT_POSITION_NO_BITMASK);
-        this->parent_->update_number_cache(name, value);
-        this->publish_state(value);
-    } 
+        if (this->parent_->send_uart_cc_command(index, (uint8_t)value, BIT_POSITION_NO_BITMASK)) {
+            this->parent_->update_number_cache(name, value);
+            this->publish_state(value);
+        }
+    }
     else if (it_i != I_NUMBER_PARAM_INDEX.end()) {
         uint8_t index = it_i->second;
-        this->parent_->send_uart_cc_command(index, (int8_t)value, BIT_POSITION_NO_BITMASK);
-        this->parent_->update_number_cache(name, value);
-        this->publish_state(value);
+        if (this->parent_->send_uart_cc_command(index, (int8_t)value, BIT_POSITION_NO_BITMASK)) {
+            this->parent_->update_number_cache(name, value);
+            this->publish_state(value);
+        }
     }
     else {
         DAIKIN_WARN(TAG, "No matching UART command for Number: %s", name.c_str());
@@ -2908,9 +2910,10 @@ void DaikinEkhheSelect::control(const std::string &value) {
     }
 
     // Update value in ESPHome
-    this->parent_->send_uart_cc_command(param_index, uart_value, bit_position);
-    this->parent_->update_select_cache(name, value);
-    this->publish_state(value);
+    if (this->parent_->send_uart_cc_command(param_index, uart_value, bit_position)) {
+        this->parent_->update_select_cache(name, value);
+        this->publish_state(value);
+    }
 }
 
 void DaikinEkhheComponent::send_prebuilt_cd_packet_(const std::vector<uint8_t> &command, TxPacketKind kind,
@@ -3455,24 +3458,23 @@ void DaikinEkhheComponent::check_pending_profile_restore_(const std::vector<uint
   reset_queued_profile_restore_();
 }
 
-void DaikinEkhheComponent::send_uart_cc_command(uint8_t index, uint8_t value, uint8_t bit_position) {
+bool DaikinEkhheComponent::send_uart_cc_command(uint8_t index, uint8_t value, uint8_t bit_position) {
     // Check that a CC packet is stored
     // since we need the last one as a basis for the new packet
     if (last_cc_packet_.empty()) {
         DAIKIN_WARN(TAG, "No CC packet received yet. Cannot send command.");
-        return;
+        return false;
     }
     if (pending_restore_.active || restore_ui_sync_.active) {
         DAIKIN_WARN(TAG, "Restore defaults in progress, ignoring single-parameter write.");
-        return;
+        return false;
     }
     if (pending_profile_restore_.active || profile_ui_sync_.active) {
         DAIKIN_WARN(TAG, "Profile restore in progress, ignoring single-parameter write.");
-        return;
+        return false;
     }
     if (pending_tx_.active || queued_tx_.active || queued_tx_.scheduled || tx_ui_sync_.active) {
-        defer_single_field_tx_(index, value, bit_position);
-        return;
+        return defer_single_field_tx_(index, value, bit_position);
     }
 
     auto_save_snapshot_if_needed_();
@@ -3524,12 +3526,13 @@ void DaikinEkhheComponent::send_uart_cc_command(uint8_t index, uint8_t value, ui
       uint32_t d2_age_ms = millis() - d2_entry->timestamp_ms;
       if (d2_age_ms <= kTxDelayAfterD2Ms) {
         schedule_queued_tx_from_d2_(*d2_entry);
-        return;
+        return true;
       }
     }
 
     DAIKIN_DBG(TAG, "TX scheduling: waiting_for_next_d2 index=%u value=0x%02X bit=%u",
                index, value, bit_position);
+    return true;
 }
 
 

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -154,7 +154,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   void update_timestamp(uint8_t hour, uint8_t minute);
 
   // Allow UART command sending for Number/Select control
-  void send_uart_cc_command(uint8_t index, uint8_t value, uint8_t bit_position);
+  bool send_uart_cc_command(uint8_t index, uint8_t value, uint8_t bit_position);
   void restore_default_settings();
   void save_known_good_profile();
   void restore_known_good_profile();

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <map>
 #include <type_traits>
+#include <vector>
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
@@ -341,6 +342,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   static constexpr uint8_t kCdContextFramesAfter = 8;
   static constexpr uint32_t kTxDelayAfterD2Ms = 75;
   static constexpr uint8_t kTxMaxRepeats = 5;
+  static constexpr uint8_t kDeferredTxMax = 8;
 
   static constexpr uint8_t kPacketMaskDD = 1 << 0;
   static constexpr uint8_t kPacketMaskD2 = 1 << 1;
@@ -442,6 +444,9 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   void send_uart_cc_packet_(const std::vector<uint8_t> &base_packet, bool apply_change,
                             uint8_t index, uint8_t value, uint8_t bit_position);
   void check_pending_tx_(const std::vector<uint8_t> &buffer);
+  bool defer_single_field_tx_(uint8_t index, uint8_t value, uint8_t bit_position);
+  bool has_deferred_user_tx_(uint8_t index, uint8_t bit_position) const;
+  void flush_deferred_user_tx_();
   void schedule_queued_tx_from_d2_(const RawFrameEntry &d2_entry);
   void send_restore_defaults_packet_(const std::vector<uint8_t> &base_packet,
                                      const std::vector<uint8_t> &packet);
@@ -568,6 +573,12 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
     uint32_t anchor_seq = 0;
   };
   QueuedTx queued_tx_;
+  struct DeferredTx {
+    uint8_t index = 0;
+    uint8_t value = 0;
+    uint8_t bit_position = kBitPositionNoBitmask;
+  };
+  std::vector<DeferredTx> deferred_user_txs_;
   struct QueuedRestore {
     bool active = false;
     bool scheduled = false;


### PR DESCRIPTION
Summary: defers single-parameter user writes while another TX/readback/UI-sync operation is active, coalesces repeated writes to the same field, suppresses stale CC updates for queued fields, and flushes the next write once the active TX state clears. Root cause: a new write could start while the previous applied TX was still waiting for UI-facing CC readback, resetting TX state and making rapid successive writes unreliable. Validation: git diff --check HEAD~1 HEAD; ESPHome 2026.1.2 production fixture compile; ESPHome 2026.1.2 debug fixture compile.

## Summary

This fixes unreliable setting changes when multiple values are changed close together from Home Assistant.

Before this change, if Home Assistant sent a second setting change while the first one was still being confirmed by the Daikin controller, the second change could be ignored or Home Assistant could briefly show the new value even though it was not actually sent.

Now the component waits its turn: if another setting change is already in progress, the next one is queued and sent afterwards.

## User Impact

This should make automations and dashboards more reliable when they update several settings at once, for example changing operational mode and target temperature in the same automation.

It also prevents Home Assistant from showing a changed value when the component rejected the write because another protected operation was active.

## Validation

- Production ESPHome fixture compiles successfully
- Debug ESPHome fixture compiles successfully
- Whitespace check passed