### PR TITLE
Fix EEV opening step decoding

### DIFF
--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -1514,6 +1514,7 @@ bool DaikinEkhheComponent::is_known_offset_(uint8_t packet_type, size_t offset, 
           DD_PACKET_G_IDX,
           DD_PACKET_H_IDX,
           DD_PACKET_I_IDX,
+          DD_PACKET_I_IDX + 1,
           DD_PACKET_DIG_IDX,
           DD_PACKET_J_FW_IDX,
           DD_PACKET_END,
@@ -2296,7 +2297,7 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
       {F_EVA_OUTLET_T_PROBE,   (int8_t)buffer[DD_PACKET_F_IDX]},
       {G_COMP_GAS_T_PROBE,     buffer[DD_PACKET_G_IDX]},
       {H_SOLAR_T_PROBE,        buffer[DD_PACKET_H_IDX]},
-      {I_EEV_STEP,             buffer[DD_PACKET_I_IDX]},
+      {I_EEV_STEP,             (float)((buffer[DD_PACKET_I_IDX] << 8) | buffer[DD_PACKET_I_IDX + 1])},
   };
 
   for (const auto &entry : sensor_values) {

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -179,7 +179,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
     DD_PACKET_F_IDX     = 12,
     DD_PACKET_G_IDX     = 13,
     DD_PACKET_H_IDX     = 14,
-    DD_PACKET_I_IDX     = 18,
+    DD_PACKET_I_IDX     = 17,
     DD_PACKET_DIG_IDX   = 21,
     DD_PACKET_J_FW_IDX  = 39,
     DD_PACKET_END       = 40,


### PR DESCRIPTION
EEV step is actually a 2-byte value since it can go up to 500. 