### PR TITLE
Add fan RPM sensor

### DIFF
--- a/.github/fixtures/debug/ci.yaml
+++ b/.github/fixtures/debug/ci.yaml
@@ -46,6 +46,8 @@ sensor:
   - platform: daikin_ekhhe
     low_water_temp_probe:
       name: "CI Debug Low Water Temperature probe"
+    fan_speed_rpm:
+      name: "CI Debug Fan Speed RPM"
     frames_captured_total:
       name: "CI Frames Captured"
 

--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -45,6 +45,8 @@ sensor:
   - platform: daikin_ekhhe
     low_water_temp_probe:
       name: "CI Low Water Temperature probe"
+    fan_speed_rpm:
+      name: "CI Fan Speed RPM"
 
 binary_sensor:
   - platform: daikin_ekhhe

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -9,6 +9,7 @@ F_EVA_OUTLET_T_PROBE    = "evaporator_outlet_gas_temp_probe"
 G_COMP_GAS_T_PROBE      = "compressor_discharge_gas_temp_probe"
 H_SOLAR_T_PROBE         = "solar_collector_temp_probe"
 I_EEV_STEP              = "eev_opening_step"
+FAN_SPEED_RPM           = "fan_speed_rpm"
 J_POWER_FW_VERSION      = "power_board_firmware_version"
 L_UI_FW_VERSION         = "ui_firmware_version"
 

--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -1516,6 +1516,8 @@ bool DaikinEkhheComponent::is_known_offset_(uint8_t packet_type, size_t offset, 
           DD_PACKET_I_IDX,
           DD_PACKET_I_IDX + 1,
           DD_PACKET_DIG_IDX,
+          DD_PACKET_FAN_RPM_IDX,
+          DD_PACKET_FAN_RPM_IDX + 1,
           DD_PACKET_J_FW_IDX,
           DD_PACKET_END,
       };
@@ -2298,6 +2300,7 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
       {G_COMP_GAS_T_PROBE,     buffer[DD_PACKET_G_IDX]},
       {H_SOLAR_T_PROBE,        buffer[DD_PACKET_H_IDX]},
       {I_EEV_STEP,             (float)((buffer[DD_PACKET_I_IDX] << 8) | buffer[DD_PACKET_I_IDX + 1])},
+      {FAN_SPEED_RPM,          (float)((buffer[DD_PACKET_FAN_RPM_IDX] << 8) | buffer[DD_PACKET_FAN_RPM_IDX + 1])},
   };
 
   for (const auto &entry : sensor_values) {

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -180,8 +180,9 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
     DD_PACKET_G_IDX     = 13,
     DD_PACKET_H_IDX     = 14,
     DD_PACKET_I_IDX     = 17,
-    DD_PACKET_DIG_IDX   = 21,
-    DD_PACKET_J_FW_IDX  = 39,
+    DD_PACKET_DIG_IDX     = 21,
+    DD_PACKET_FAN_RPM_IDX = 26,
+    DD_PACKET_J_FW_IDX    = 39,
     DD_PACKET_END       = 40,
     DD_PACKET_SIZE      = 41,
   };

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -16,6 +16,7 @@ static const std::string F_EVA_OUTLET_T_PROBE    = "evaporator_outlet_gas_temp_p
 static const std::string G_COMP_GAS_T_PROBE      = "compressor_discharge_gas_temp_probe";
 static const std::string H_SOLAR_T_PROBE         = "solar_collector_temp_probe";
 static const std::string I_EEV_STEP              = "eev_opening_step";
+static const std::string FAN_SPEED_RPM           = "fan_speed_rpm";
 static const std::string J_POWER_FW_VERSION      = "power_board_firmware_version";
 static const std::string L_UI_FW_VERSION         = "ui_firmware_version";
 

--- a/components/daikin_ekhhe/sensor.py
+++ b/components/daikin_ekhhe/sensor.py
@@ -30,6 +30,7 @@ TYPES = [
     G_COMP_GAS_T_PROBE,
     H_SOLAR_T_PROBE,
     I_EEV_STEP,
+    FAN_SPEED_RPM,
 ]
 
 DEBUG_TYPES = [
@@ -109,7 +110,13 @@ CONFIG_SCHEMA = (
                 accuracy_decimals=0,
                 #device_class=DEVICE_CLASS_NONE,
                 state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,  		
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(FAN_SPEED_RPM): sensor.sensor_schema(
+                unit_of_measurement="rpm",
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(FRAMES_CAPTURED_TOTAL): sensor.sensor_schema(
                 unit_of_measurement=UNIT_EMPTY,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,7 @@ Useful read-only values for monitoring the heat pump:
 - `compressor_discharge_gas_temp_probe`
 - `solar_collector_temp_probe`
 - `eev_opening_step`
+- `fan_speed_rpm`
 
 ### Basic Operation
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -24,7 +24,7 @@ Bus observations:
 The following areas still need reverse engineering:
 
 - Detailed status flags.
-- Detailed equipment/component state, such as fan state and other internal actuators.
+- Detailed equipment/component state beyond the currently decoded fan RPM.
 - Fault codes, error codes, and protection codes.
 - Status-only fields in `DD`.
 - Remaining unknown or partially decoded bitmasks.

--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -64,6 +64,8 @@ sensor:
       name: "H: Solar Collector Temperature probe"
     eev_opening_step:
       name: "I: EEV opening step"
+    fan_speed_rpm:
+      name: "Fan speed RPM"
     frames_captured_total:
       name: "Daikin Frames Captured"
     frames_dropped_total:

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -63,6 +63,8 @@ sensor:
       name: "H: Solar Collector Temperature probe"
     eev_opening_step:
       name: "I: EEV opening step"
+    fan_speed_rpm:
+      name: "Fan speed RPM"
 
 binary_sensor:
   - platform: daikin_ekhhe


### PR DESCRIPTION
## Summary

Adds a new optional `fan_speed_rpm` sensor decoded from the confirmed `DD[26..27]` runtime field. This exposes the evaporator fan speed directly in Home Assistant as an RPM reading.

## Implementation

- Decodes `DD[26..27]` as an unsigned 16-bit fan RPM value.
- Registers `fan_speed_rpm` as an optional diagnostic sensor with `rpm` units.
- Marks the two DD bytes as known so debug unknown-field output no longer treats them as unexplained.
- Updates the full/debug examples, CI fixtures, and configuration documentation.

## Validation

- `esphome config .github/fixtures/minimal/ci.yaml`
- `esphome config .github/fixtures/production/ci.yaml`
- `esphome config .github/fixtures/debug/ci.yaml`

A local full compile was started, but stopped because PlatformIO was unpacking a fresh ESP32 framework cache with a long estimate in the sandbox. CI should perform the full compile.
