### PR TITLE
Add silent mode switch

### DIFF
--- a/.github/fixtures/debug/ci.yaml
+++ b/.github/fixtures/debug/ci.yaml
@@ -120,6 +120,8 @@ text_sensor:
 
 switch:
   - platform: daikin_ekhhe
+    silent_mode:
+      name: "CI Silent Mode"
     daikin_debug_freeze:
       name: "CI Debug Freeze"
 

--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -95,6 +95,11 @@ select:
     evaporator_fan_compressor_off_mode:
       name: "CI P58 Evaporator Fan Compressor Off Mode"
 
+switch:
+  - platform: daikin_ekhhe
+    silent_mode:
+      name: "CI Silent Mode"
+
 button:
   - platform: daikin_ekhhe
     daikin_restore_default_settings:

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -32,6 +32,7 @@ PA_HEAT_PUMP_TEMP_UNSUITABLE_ALARM = "pa_heat_pump_temperature_unsuitable_alarm"
 
 POWER_STATUS            = "power_status"
 OPERATIONAL_MODE        = "operational_mode"
+SILENT_MODE             = "silent_mode"
 CURRENT_TIME            = "current_time"
 AUTO_T_TEMPERATURE      = "auto_target_temperature"
 ECO_T_TEMPERATURE       = "eco_target_temperature"

--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -25,6 +25,7 @@ static const uint8_t C1_PACKET_START_BYTE = 0xC1;
 static const uint8_t C2_PACKET_START_BYTE = 0xC2;
 static const uint8_t CC_PACKET_START_BYTE = 0xCC;
 static const uint8_t CD_PACKET_START_BYTE = 0xCD;
+static const uint8_t SILENT_MODE_BIT_POSITION = 6;
 
 
 // Packet definitions
@@ -256,6 +257,8 @@ static const ManagedFieldSpec PROFILE_MANAGED_FIELDS[] = {
      DaikinEkhheComponent::D2_PACKET_MASK1_IDX, 0, 1},
     {"OPERATIONAL_MODE", DaikinEkhheComponent::CC_PACKET_MODE_IDX, BIT_POSITION_NO_BITMASK, 0,
      DaikinEkhheComponent::D2_PACKET_MODE_IDX, BIT_POSITION_NO_BITMASK, 0},
+    {"SILENT_MODE", DaikinEkhheComponent::CC_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION, 1,
+     DaikinEkhheComponent::D2_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION, 1},
     {"P1", DaikinEkhheComponent::CC_PACKET_P1_IDX, BIT_POSITION_NO_BITMASK, 0,
      DaikinEkhheComponent::D2_PACKET_P1_IDX, BIT_POSITION_NO_BITMASK, 0},
     {"P2", DaikinEkhheComponent::CC_PACKET_P2_IDX, BIT_POSITION_NO_BITMASK, 0,
@@ -2483,6 +2486,21 @@ void DaikinEkhheComponent::parse_d2_packet(std::vector<uint8_t> buffer) {
     set_select_value(param_name, value);
   }
 
+#if defined(USE_SWITCH)
+  if (D2_PACKET_MASK2_IDX < buffer.size()) {
+    const bool pending_silent_write =
+        pending_tx_.active && pending_tx_.family == TxPacketFamily::MAIN &&
+        pending_tx_.index == CC_PACKET_MASK2_IDX &&
+        pending_tx_.bit_position == SILENT_MODE_BIT_POSITION;
+    const bool deferred_silent_write =
+        has_deferred_user_tx_(TxPacketFamily::MAIN, CC_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION);
+    if (!pending_silent_write && !deferred_silent_write) {
+      set_switch_value(SILENT_MODE,
+                       extract_field_value(buffer, D2_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION, 1) != 0);
+    }
+  }
+#endif
+
   update_timestamp(buffer[D2_PACKET_HOUR_IDX], buffer[D2_PACKET_MIN_IDX]);
 
   return;
@@ -2661,6 +2679,29 @@ void DaikinEkhheComponent::parse_cc_packet(std::vector<uint8_t> buffer) {
     set_select_value(param_name, value);
   }
 
+#if defined(USE_SWITCH)
+  if (CC_PACKET_MASK2_IDX < buffer.size()) {
+    const bool pending_silent_write =
+        pending_tx_.active && pending_tx_.family == TxPacketFamily::MAIN &&
+        pending_tx_.index == CC_PACKET_MASK2_IDX &&
+        pending_tx_.bit_position == SILENT_MODE_BIT_POSITION;
+    const bool deferred_silent_write =
+        has_deferred_user_tx_(TxPacketFamily::MAIN, CC_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION);
+    const bool waiting_for_silent_ui_sync =
+        tx_ui_sync_.active && tx_ui_sync_.family == TxPacketFamily::MAIN &&
+        tx_ui_sync_.index == CC_PACKET_MASK2_IDX &&
+        tx_ui_sync_.bit_position == SILENT_MODE_BIT_POSITION && !cc_sync_matched;
+    const bool waiting_for_silent_profile_sync =
+        (pending_profile_active || (profile_ui_sync_.active && !profile_cc_sync_matched)) &&
+        is_profile_managed_field(CC_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION);
+    if (!pending_silent_write && !deferred_silent_write && !waiting_for_silent_ui_sync &&
+        !waiting_for_silent_profile_sync) {
+      set_switch_value(SILENT_MODE,
+                       extract_field_value(buffer, CC_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION, 1) != 0);
+    }
+  }
+#endif
+
   set_text_sensor_value_(L_UI_FW_VERSION, "U" + std::to_string(buffer[CC_PACKET_L_FW_IDX]));
 
   update_timestamp(buffer[CC_PACKET_HOUR_IDX], buffer[CC_PACKET_MIN_IDX]);
@@ -2801,6 +2842,14 @@ void DaikinEkhheComponent::register_debug_select(DaikinEkhheDebugSelect *select)
   }
 }
 
+#if defined(USE_SWITCH)
+void DaikinEkhheComponent::register_switch(const std::string &switch_name, switch_::Switch *sw) {
+  if (sw != nullptr) {
+    switches_[switch_name] = sw;
+  }
+}
+#endif
+
 #if DAIKIN_EKHHE_DEBUG && defined(USE_SWITCH)
 void DaikinEkhheComponent::register_debug_switch(DaikinEkhheDebugSwitch *sw) {
   this->debug_freeze_switch_ = sw;
@@ -2864,6 +2913,22 @@ void DaikinEkhheComponent::set_binary_sensor_value(const std::string &sensor_nam
     }
   }
 }
+
+#if defined(USE_SWITCH)
+void DaikinEkhheComponent::set_switch_value(const std::string &switch_name, bool value) {
+  if (switches_.find(switch_name) != switches_.end()) {
+    if (!cycle_publish_allowed_) {
+      return;
+    }
+    if (should_publish_bool_(switch_name, value, last_published_switch_values_,
+                             last_published_switch_ms_, kSlowPublishRefreshMs)) {
+      defer([this, switch_name, value]() {
+        switches_[switch_name]->publish_state(value);
+      });
+    }
+  }
+}
+#endif
 
 void DaikinEkhheComponent::set_number_value(const std::string &number_name, float value) {
   // This sets a number value that's been gotten from the UART stream, not something that's 
@@ -2956,6 +3021,62 @@ void DaikinEkhheComponent::update_select_cache(const std::string &select_name, c
   last_published_select_values_[select_name] = value;
   last_published_select_ms_[select_name] = now;
 }
+
+#if defined(USE_SWITCH)
+void DaikinEkhheComponent::update_switch_cache(const std::string &switch_name, bool value) {
+  uint32_t now = millis();
+  last_published_switch_values_[switch_name] = value;
+  last_published_switch_ms_[switch_name] = now;
+}
+
+bool DaikinEkhheComponent::current_operational_mode_(uint8_t &mode) const {
+  if (last_d2_packet_.size() > D2_PACKET_MODE_IDX) {
+    mode = last_d2_packet_[D2_PACKET_MODE_IDX];
+    return true;
+  }
+  if (last_cc_packet_.size() > CC_PACKET_MODE_IDX) {
+    mode = last_cc_packet_[CC_PACKET_MODE_IDX];
+    return true;
+  }
+  return false;
+}
+
+bool DaikinEkhheComponent::silent_mode_allowed_mode_(uint8_t mode) const {
+  return mode == kOperationalModeAuto || mode == kOperationalModeEco || mode == kOperationalModeBoost;
+}
+
+void DaikinEkhheComponent::publish_silent_mode_from_latest_packet_() {
+  bool enabled = false;
+  if (last_d2_packet_.size() > D2_PACKET_MASK2_IDX) {
+    enabled = extract_field_value(last_d2_packet_, D2_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION, 1) != 0;
+  } else if (last_cc_packet_.size() > CC_PACKET_MASK2_IDX) {
+    enabled = extract_field_value(last_cc_packet_, CC_PACKET_MASK2_IDX, SILENT_MODE_BIT_POSITION, 1) != 0;
+  }
+  set_switch_value(SILENT_MODE, enabled);
+}
+
+bool DaikinEkhheComponent::set_silent_mode(bool enabled) {
+  if (enabled) {
+    uint8_t mode = 0;
+    if (!current_operational_mode_(mode)) {
+      DAIKIN_WARN(TAG, "Silent mode cannot be enabled before an operational mode has been received.");
+      publish_silent_mode_from_latest_packet_();
+      return false;
+    }
+    if (!silent_mode_allowed_mode_(mode)) {
+      DAIKIN_WARN(TAG, "Silent mode can only be enabled in Auto, Eco, or Boost mode; current mode=%u", mode);
+      publish_silent_mode_from_latest_packet_();
+      return false;
+    }
+  }
+
+  if (!send_uart_cc_command(CC_PACKET_MASK2_IDX, enabled ? 1 : 0, SILENT_MODE_BIT_POSITION, 1)) {
+    publish_silent_mode_from_latest_packet_();
+    return false;
+  }
+  return true;
+}
+#endif
 
 uint8_t DaikinEkhheComponent::ekhhe_checksum(const std::vector<uint8_t>& data_bytes) {
   // Compute the checksum as (sum of data bytes) mod 256 + 170
@@ -3138,6 +3259,26 @@ void DaikinEkhheDebugSwitch::write_state(bool state) {
     return;
   }
   this->parent_->set_debug_freeze(state);
+}
+#endif
+
+#if defined(USE_SWITCH)
+void DaikinEkhheSwitch::write_state(bool state) {
+  if (this->parent_ == nullptr) {
+    DAIKIN_WARN(TAG, "Parent component is null, cannot send Switch command.");
+    return;
+  }
+
+  auto name = this->internal_id_;
+  if (name == SILENT_MODE) {
+    if (this->parent_->set_silent_mode(state)) {
+      this->parent_->update_switch_cache(name, state);
+      this->publish_state(state);
+    }
+    return;
+  }
+
+  DAIKIN_WARN(TAG, "No matching UART command for Switch: %s", name.c_str());
 }
 #endif
 
@@ -3751,6 +3892,12 @@ void DaikinEkhheComponent::check_pending_tx_(const std::vector<uint8_t> &buffer)
         set_select_value(entry.first, field_value);
       }
     }
+#if defined(USE_SWITCH)
+    if (pending_tx_.family == TxPacketFamily::MAIN && index == CC_PACKET_MASK2_IDX &&
+        pending_tx_.bit_position == SILENT_MODE_BIT_POSITION) {
+      set_switch_value(SILENT_MODE, field_value != 0);
+    }
+#endif
   }
   tx_waiting_for_first_rx_ = false;
   tx_waiting_for_first_cc_ = false;

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -15,7 +15,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/select/select.h"
-#if DAIKIN_EKHHE_DEBUG && defined(USE_SWITCH)
+#if defined(USE_SWITCH)
 #include "esphome/components/switch/switch.h"
 #endif
 #if defined(USE_BUTTON)
@@ -73,6 +73,19 @@ class DaikinEkhheDebugSelect : public select::Select, public Component {
  private:
   DaikinEkhheComponent *parent_;
 };
+
+#if defined(USE_SWITCH)
+class DaikinEkhheSwitch : public switch_::Switch {
+ public:
+  void write_state(bool state) override;
+  void set_parent(DaikinEkhheComponent *parent) { this->parent_ = parent; }
+  void set_internal_id(const std::string &id) { this->internal_id_ = id; }
+
+ private:
+  DaikinEkhheComponent *parent_;
+  std::string internal_id_;
+};
+#endif
 
 #if DAIKIN_EKHHE_DEBUG && defined(USE_SWITCH)
 class DaikinEkhheDebugSwitch : public switch_::Switch {
@@ -138,6 +151,9 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   void register_debug_text_sensor(const std::string &sensor_name, esphome::text_sensor::TextSensor *sensor);
   void register_debug_sensor(const std::string &sensor_name, esphome::sensor::Sensor *sensor);
   void register_debug_select(DaikinEkhheDebugSelect *select);
+#if defined(USE_SWITCH)
+  void register_switch(const std::string &switch_name, switch_::Switch *sw);
+#endif
 #if DAIKIN_EKHHE_DEBUG && defined(USE_SWITCH)
   void register_debug_switch(DaikinEkhheDebugSwitch *sw);
 #endif
@@ -154,6 +170,9 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   void set_binary_sensor_value(const std::string &sensor_name, bool value);
   void set_number_value(const std::string &number_name, float value);
   void set_select_value(const std::string &select_name, int value);
+#if defined(USE_SWITCH)
+  void set_switch_value(const std::string &switch_name, bool value);
+#endif
   void update_timestamp(uint8_t hour, uint8_t minute);
 
   // Allow UART command sending for Number/Select control
@@ -167,6 +186,10 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   void set_debug_freeze(bool enabled);
   void update_number_cache(const std::string &number_name, float value);
   void update_select_cache(const std::string &select_name, const std::string &value);
+#if defined(USE_SWITCH)
+  void update_switch_cache(const std::string &switch_name, bool value);
+  bool set_silent_mode(bool enabled);
+#endif
 
 
   enum EkkheDDPacket {
@@ -383,6 +406,9 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   static constexpr uint32_t kMaxTxDelayAfterD2Ms = 250;
   static constexpr uint8_t kTxMaxRepeats = 5;
   static constexpr uint8_t kDeferredTxMax = 8;
+  static constexpr uint8_t kOperationalModeAuto = 0;
+  static constexpr uint8_t kOperationalModeEco = 1;
+  static constexpr uint8_t kOperationalModeBoost = 2;
 
   static constexpr uint8_t kPacketMaskDD = 1 << 0;
   static constexpr uint8_t kPacketMaskD2 = 1 << 1;
@@ -398,6 +424,9 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   std::map<std::string, esphome::binary_sensor::BinarySensor *> binary_sensors_;
   std::map<std::string, esphome::number::Number *> numbers_;
   std::map<std::string, DaikinEkhheSelect *> selects_;
+#if defined(USE_SWITCH)
+  std::map<std::string, switch_::Switch *> switches_;
+#endif
   std::map<std::string, esphome::text_sensor::TextSensor *> text_sensors_;
   text_sensor::TextSensor *timestamp_sensor_ = nullptr;
   std::map<std::string, esphome::text_sensor::TextSensor *> debug_text_sensors_;
@@ -469,6 +498,11 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   std::string format_unknown_fields_(const RawFrameEntry &entry) const;
   std::string format_frame_diff_(const RawFrameEntry &entry, const RawFrameEntry *prev) const;
   bool is_known_offset_(uint8_t packet_type, size_t offset, size_t length) const;
+#if defined(USE_SWITCH)
+  bool current_operational_mode_(uint8_t &mode) const;
+  bool silent_mode_allowed_mode_(uint8_t mode) const;
+  void publish_silent_mode_from_latest_packet_();
+#endif
   uint8_t packet_type_from_string_(const std::string &value) const;
   std::string packet_type_to_string_(uint8_t packet_type) const;
   enum class TxPacketKind : uint8_t {
@@ -719,6 +753,10 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   std::map<std::string, uint32_t> last_published_binary_ms_;
   std::map<std::string, std::string> last_published_select_values_;
   std::map<std::string, uint32_t> last_published_select_ms_;
+#if defined(USE_SWITCH)
+  std::map<std::string, bool> last_published_switch_values_;
+  std::map<std::string, uint32_t> last_published_switch_ms_;
+#endif
   std::map<std::string, std::string> last_published_text_values_;
   std::map<std::string, uint32_t> last_published_text_ms_;
   std::string last_published_timestamp_;

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -39,6 +39,7 @@ static const std::string PA_HEAT_PUMP_TEMP_UNSUITABLE_ALARM = "pa_heat_pump_temp
 
 static const std::string POWER_STATUS            = "power_status";
 static const std::string OPERATIONAL_MODE        = "operational_mode";
+static const std::string SILENT_MODE             = "silent_mode";
 static const std::string CURRENT_TIME            = "current_time";
 
 static const std::string AUTO_T_TEMPERATURE      = "auto_target_temperature";

--- a/components/daikin_ekhhe/switch.py
+++ b/components/daikin_ekhhe/switch.py
@@ -1,10 +1,14 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
-from esphome.const import CONF_ID, ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import ENTITY_CATEGORY_CONFIG, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import CONF_EKHHE_ID, DaikinEkhhe, daikin_ekhhe_ns
-from .const import DAIKIN_DEBUG_FREEZE
+from .const import DAIKIN_DEBUG_FREEZE, SILENT_MODE
+
+DaikinEkhheSwitch = daikin_ekhhe_ns.class_(
+    "DaikinEkhheSwitch", switch.Switch, cg.Component
+)
 
 DaikinEkhheDebugSwitch = daikin_ekhhe_ns.class_(
     "DaikinEkhheDebugSwitch", switch.Switch, cg.Component
@@ -13,6 +17,9 @@ DaikinEkhheDebugSwitch = daikin_ekhhe_ns.class_(
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_EKHHE_ID): cv.use_id(DaikinEkhhe),
+        cv.Optional(SILENT_MODE): switch.switch_schema(
+            DaikinEkhheSwitch, entity_category=ENTITY_CATEGORY_CONFIG
+        ),
         cv.Optional(DAIKIN_DEBUG_FREEZE): switch.switch_schema(
             DaikinEkhheDebugSwitch, entity_category=ENTITY_CATEGORY_DIAGNOSTIC
         ),
@@ -22,6 +29,12 @@ CONFIG_SCHEMA = cv.Schema(
 
 async def to_code(config):
     hub = await cg.get_variable(config[CONF_EKHHE_ID])
+    if SILENT_MODE in config:
+        conf = config[SILENT_MODE]
+        sw = await switch.new_switch(conf)
+        cg.add(hub.register_switch(SILENT_MODE, sw))
+        cg.add(sw.set_parent(hub))
+        cg.add(sw.set_internal_id(SILENT_MODE))
     if DAIKIN_DEBUG_FREEZE in config:
         conf = config[DAIKIN_DEBUG_FREEZE]
         sw = await switch.new_switch(conf)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -68,9 +68,12 @@ Common day-to-day controls and state indicators:
 
 - `power_status`
 - `operational_mode`
+- `silent_mode`
 - `hp_active`
 - `eh_active`
 - `vacation_days`
+
+`silent_mode` can be enabled only while the unit is in Auto, Eco, or Boost mode. Disabling it is allowed from any mode so the setting can be cleared safely if the operating mode changes.
 
 ### Fault And Alarm Indicators
 

--- a/examples/debug.yaml
+++ b/examples/debug.yaml
@@ -290,6 +290,8 @@ select:
 
 switch:
   - platform: daikin_ekhhe
+    silent_mode:
+      name: "Silent mode"
     daikin_debug_freeze:
       name: "Daikin Debug Freeze"
 

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -265,6 +265,11 @@ select:
     evaporator_fan_compressor_off_mode:
       name: "P58: Evaporator fan compressor off mode"
 
+switch:
+  - platform: daikin_ekhhe
+    silent_mode:
+      name: "Silent mode"
+
 text_sensor:
   - platform: daikin_ekhhe
     current_time:


### PR DESCRIPTION
## Summary
- Adds an optional `silent_mode` switch for the confirmed silent-mode flag.
- Writes byte 2 bit 6 through the existing main-block TX/retry path.
- Allows enabling only while the unit is in Auto, Eco, or Boost mode; disabling remains allowed from any mode.
- Includes silent mode in known-good and auto snapshot managed fields.
- Updates examples, configuration docs, and CI fixtures.

## Validation
- `esphome config` for minimal, production, and debug fixtures
- `esphome compile` for production fixture
- `esphome compile` for minimal fixture
- `git diff --check`