### PR TITLE
Add master fault binary sensor

### DIFF
--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -57,6 +57,8 @@ binary_sensor:
       name: "CI Heat Pump Active"
     eh_active:
       name: "CI Electric Heater Active"
+    master_fault:
+      name: "CI Master Fault"
     p01_tank_lower_probe_fault:
       name: "CI P01 Tank Lower Probe Fault"
     p02_tank_upper_probe_fault:

--- a/components/daikin_ekhhe/binary_sensor.py
+++ b/components/daikin_ekhhe/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor
-from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
+from esphome.const import DEVICE_CLASS_PROBLEM, ENTITY_CATEGORY_DIAGNOSTIC
 
 from . import (
     CONF_EKHHE_ID,
@@ -15,6 +15,7 @@ TYPES =[
     DIG1_CONFIG,
     DIG2_CONFIG,
     DIG3_CONFIG,
+    MASTER_FAULT,
     P01_TANK_LOWER_PROBE_FAULT,
     P02_TANK_UPPER_PROBE_FAULT,
     P03_DEFROST_PROBE_FAULT,
@@ -50,6 +51,10 @@ CONFIG_SCHEMA = (
             cv.Optional(DIG3_CONFIG): binary_sensor.binary_sensor_schema(
                 #device_class=DEVICE_CLASS_NONE,
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,  		
+            ),
+            cv.Optional(MASTER_FAULT): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_PROBLEM,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(P01_TANK_LOWER_PROBE_FAULT): binary_sensor.binary_sensor_schema(
                 entity_category=ENTITY_CATEGORY_DIAGNOSTIC,

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -17,6 +17,7 @@ DIG1_CONFIG             = "dig1_config"
 DIG2_CONFIG             = "dig2_config"
 DIG3_CONFIG             = "dig3_config"
 
+MASTER_FAULT = "master_fault"
 P01_TANK_LOWER_PROBE_FAULT = "p01_tank_lower_probe_fault"
 P02_TANK_UPPER_PROBE_FAULT = "p02_tank_upper_probe_fault"
 P03_DEFROST_PROBE_FAULT = "p03_defrost_probe_fault"

--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -2057,22 +2057,42 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
   set_text_sensor_value_(J_POWER_FW_VERSION, "U" + std::to_string(buffer[DD_PACKET_J_FW_IDX]));
 
   // update binary_sensors
+  const bool p01_tank_lower_probe_fault = (buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x04) != 0;
+  const bool p02_tank_upper_probe_fault = (buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x02) != 0;
+  const bool p03_defrost_probe_fault = (buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x01) != 0;
+  const bool p04_inlet_air_probe_fault = (buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x08) != 0;
+  const bool p05_evaporator_inlet_probe_fault = (buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x80) != 0;
+  const bool p06_evaporator_outlet_probe_fault = (buffer[DD_PACKET_ALARM_IDX] & 0x01) != 0;
+  const bool p07_compressor_flow_probe_fault = (buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x10) != 0;
+  const bool p08_solar_collector_probe_fault = (buffer[DD_PACKET_ALARM2_IDX] & 0x01) != 0;
+  const bool e01_high_pressure_protection = (buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x40) != 0;
+  const bool e02_solar_recirculation_alarm = (buffer[DD_PACKET_ALARM_IDX] & 0x02) != 0;
+  const bool e03_electronic_fan_fault = (buffer[DD_PACKET_ALARM2_IDX] & 0x08) != 0;
+  const bool pa_heat_pump_temp_unsuitable_alarm = (buffer[DD_PACKET_ALARM_IDX] & 0x10) != 0;
+  const bool master_fault = p01_tank_lower_probe_fault || p02_tank_upper_probe_fault || p03_defrost_probe_fault ||
+                            p04_inlet_air_probe_fault || p05_evaporator_inlet_probe_fault ||
+                            p06_evaporator_outlet_probe_fault || p07_compressor_flow_probe_fault ||
+                            p08_solar_collector_probe_fault || e01_high_pressure_protection ||
+                            e02_solar_recirculation_alarm || e03_electronic_fan_fault ||
+                            pa_heat_pump_temp_unsuitable_alarm;
+
   std::map<std::string, bool> binary_sensor_values = {
       {DIG1_CONFIG, (bool)(buffer[DD_PACKET_DIG_IDX] & 0x01)},
       {DIG2_CONFIG, (bool)(buffer[DD_PACKET_DIG_IDX] & 0x02)},
       {DIG3_CONFIG, (bool)(buffer[DD_PACKET_DIG_IDX] & 0x04)},
-      {P01_TANK_LOWER_PROBE_FAULT, (bool)(buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x04)},
-      {P02_TANK_UPPER_PROBE_FAULT, (bool)(buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x02)},
-      {P03_DEFROST_PROBE_FAULT, (bool)(buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x01)},
-      {P04_INLET_AIR_PROBE_FAULT, (bool)(buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x08)},
-      {P05_EVAPORATOR_INLET_PROBE_FAULT, (bool)(buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x80)},
-      {P06_EVAPORATOR_OUTLET_PROBE_FAULT, (bool)(buffer[DD_PACKET_ALARM_IDX] & 0x01)},
-      {P07_COMPRESSOR_FLOW_PROBE_FAULT, (bool)(buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x10)},
-      {P08_SOLAR_COLLECTOR_PROBE_FAULT, (bool)(buffer[DD_PACKET_ALARM2_IDX] & 0x01)},
-      {E01_HIGH_PRESSURE_PROTECTION, (bool)(buffer[DD_PACKET_PROBE_FAULT_IDX] & 0x40)},
-      {E02_SOLAR_RECIRCULATION_ALARM, (bool)(buffer[DD_PACKET_ALARM_IDX] & 0x02)},
-      {E03_ELECTRONIC_FAN_FAULT, (bool)(buffer[DD_PACKET_ALARM2_IDX] & 0x08)},
-      {PA_HEAT_PUMP_TEMP_UNSUITABLE_ALARM, (bool)(buffer[DD_PACKET_ALARM_IDX] & 0x10)},
+      {MASTER_FAULT, master_fault},
+      {P01_TANK_LOWER_PROBE_FAULT, p01_tank_lower_probe_fault},
+      {P02_TANK_UPPER_PROBE_FAULT, p02_tank_upper_probe_fault},
+      {P03_DEFROST_PROBE_FAULT, p03_defrost_probe_fault},
+      {P04_INLET_AIR_PROBE_FAULT, p04_inlet_air_probe_fault},
+      {P05_EVAPORATOR_INLET_PROBE_FAULT, p05_evaporator_inlet_probe_fault},
+      {P06_EVAPORATOR_OUTLET_PROBE_FAULT, p06_evaporator_outlet_probe_fault},
+      {P07_COMPRESSOR_FLOW_PROBE_FAULT, p07_compressor_flow_probe_fault},
+      {P08_SOLAR_COLLECTOR_PROBE_FAULT, p08_solar_collector_probe_fault},
+      {E01_HIGH_PRESSURE_PROTECTION, e01_high_pressure_protection},
+      {E02_SOLAR_RECIRCULATION_ALARM, e02_solar_recirculation_alarm},
+      {E03_ELECTRONIC_FAN_FAULT, e03_electronic_fan_fault},
+      {PA_HEAT_PUMP_TEMP_UNSUITABLE_ALARM, pa_heat_pump_temp_unsuitable_alarm},
   };
 
   for (const auto &entry : binary_sensor_values) {

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -24,6 +24,7 @@ static const std::string DIG1_CONFIG             = "dig1_config";
 static const std::string DIG2_CONFIG             = "dig2_config";
 static const std::string DIG3_CONFIG             = "dig3_config";
 
+static const std::string MASTER_FAULT = "master_fault";
 static const std::string P01_TANK_LOWER_PROBE_FAULT = "p01_tank_lower_probe_fault";
 static const std::string P02_TANK_UPPER_PROBE_FAULT = "p02_tank_upper_probe_fault";
 static const std::string P03_DEFROST_PROBE_FAULT = "p03_defrost_probe_fault";

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,7 @@ Common day-to-day controls and state indicators:
 
 Read-only binary sensors for confirmed display faults and alarms:
 
+- `master_fault`
 - `p01_tank_lower_probe_fault`
 - `p02_tank_upper_probe_fault`
 - `p03_defrost_probe_fault`
@@ -93,6 +94,9 @@ Read-only binary sensors for confirmed display faults and alarms:
 
 These indicators mirror observed display states. Use the Daikin display and
 manual as the primary diagnostic reference when a fault is active.
+
+`master_fault` is an aggregate OR of the confirmed fault/alarm indicators and
+is intended as the simplest Home Assistant automation trigger.
 
 `E04` and `E08` are not exposed yet. They are intentionally omitted because
 they have not been reproducibly observed on this unit in a bus-visible form:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -102,6 +102,9 @@ Confirmed indicators currently include `P01` through `P08`, `E01`, `E02`,
 `PA` before settling into `P04`; exposing both sensors lets Home Assistant show
 that transition instead of hiding it.
 
+Use `master_fault` when you only need a single alert/automation trigger. It is
+on whenever any confirmed fault/protection/alarm indicator is active.
+
 `E04` and `E08` are intentionally not included at this time. They are not just
 missing from the entity list; they have not been reproduced with a reliable
 bus-visible status bit. In particular, `E04` may depend on hardware/manual

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -79,6 +79,8 @@ binary_sensor:
       name: "Heat pump active"
     eh_active:
       name: "Electric heater active"
+    master_fault:
+      name: "Master fault"
     p01_tank_lower_probe_fault:
       name: "P01: Tank lower probe fault"
     p02_tank_upper_probe_fault:

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -47,6 +47,8 @@ sensor:
 
 binary_sensor:
   - platform: daikin_ekhhe
+    master_fault:
+      name: "Fault active"
     hp_active:
       name: "Heat pump active"
     eh_active:


### PR DESCRIPTION
Adds an optional `master_fault` binary sensor that turns on whenever any confirmed fault/protection/alarm indicator is active. This gives Home Assistant users one simple automation/alert trigger while preserving the existing individual P01-P08, E01-E03, and PA diagnostic sensors.\n\nAlso updates the minimal/full examples, production CI fixture, and docs to show the new entity.\n\nValidation:\n- `esphome config .github/fixtures/production/ci.yaml`\n- `esphome config .github/fixtures/minimal/ci.yaml`\n- Production compile was started locally but stopped during slow ESP-IDF component preparation; GitHub CI will run the full compile.