### PR TITLE
Add communication error diagnostic sensor

### DIFF
--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -59,6 +59,8 @@ binary_sensor:
       name: "CI Electric Heater Active"
     master_fault:
       name: "CI Master Fault"
+    communication_error:
+      name: "CI Communication Error"
     p01_tank_lower_probe_fault:
       name: "CI P01 Tank Lower Probe Fault"
     p02_tank_upper_probe_fault:

--- a/components/daikin_ekhhe/binary_sensor.py
+++ b/components/daikin_ekhhe/binary_sensor.py
@@ -24,6 +24,11 @@ BINARY_SENSOR_SPECS = [
         device_class=DEVICE_CLASS_PROBLEM,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    BinarySensorSchemaSpec(
+        COMMUNICATION_ERROR,
+        device_class=DEVICE_CLASS_PROBLEM,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
     *[
         BinarySensorSchemaSpec(key, entity_category=ENTITY_CATEGORY_DIAGNOSTIC)
         for key in [

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -17,6 +17,7 @@ DIG2_CONFIG             = "dig2_config"
 DIG3_CONFIG             = "dig3_config"
 
 MASTER_FAULT = "master_fault"
+COMMUNICATION_ERROR = "communication_error"
 P01_TANK_LOWER_PROBE_FAULT = "p01_tank_lower_probe_fault"
 P02_TANK_UPPER_PROBE_FAULT = "p02_tank_upper_probe_fault"
 P03_DEFROST_PROBE_FAULT = "p03_defrost_probe_fault"

--- a/components/daikin_ekhhe/daikin_ekhhe.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe.cpp
@@ -4,6 +4,7 @@
 #include "daikin_ekhhe_log.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <numeric>
 
 namespace esphome {
@@ -14,6 +15,7 @@ using namespace daikin_ekhhe;
 static const char *const TAG = "daikin_ekhhe";
 
 void DaikinEkhheComponent::setup() {
+  this->communication_health_start_ms_ = millis();
   this->known_good_profile_pref_ =
       global_preferences->make_preference<StoredProfileBlob>(KNOWN_GOOD_PROFILE_PREF_KEY, true);
   this->auto_snapshot_pref_ =
@@ -23,11 +25,13 @@ void DaikinEkhheComponent::setup() {
 }
 
 void DaikinEkhheComponent::loop() {
+  const unsigned long now = millis();
+  check_communication_error_(now);
+
   if (processing_updates_ || uart_tx_active_) {
     return;
   }
 
-  const unsigned long now = millis();
   if (!uart_active_) {
     if (now - last_process_time_ >= update_interval_ || last_process_time_ == 0) {
       start_uart_cycle();
@@ -62,6 +66,54 @@ void DaikinEkhheComponent::loop() {
   if (packet_set_complete()) {
     process_packet_set();
   }
+}
+
+uint32_t DaikinEkhheComponent::communication_error_timeout_ms_() const {
+  const uint32_t scaled_interval =
+      this->update_interval_ > (UINT32_MAX / 3UL) ? UINT32_MAX : static_cast<uint32_t>(this->update_interval_ * 3UL);
+  return std::max(kCommunicationErrorMinTimeoutMs, scaled_interval);
+}
+
+void DaikinEkhheComponent::check_communication_error_(uint32_t now_ms) {
+  if (binary_sensors_.find(COMMUNICATION_ERROR) == binary_sensors_.end()) {
+    return;
+  }
+
+  const uint32_t reference_ms =
+      last_valid_cycle_ms_ != 0 ? last_valid_cycle_ms_ : communication_health_start_ms_;
+  if ((now_ms - reference_ms) < communication_error_timeout_ms_()) {
+    return;
+  }
+
+  publish_communication_error_(true, now_ms);
+}
+
+void DaikinEkhheComponent::publish_communication_error_(bool error, uint32_t now_ms) {
+  auto sensor_it = binary_sensors_.find(COMMUNICATION_ERROR);
+  if (sensor_it == binary_sensors_.end() || sensor_it->second == nullptr) {
+    return;
+  }
+
+  if (!should_publish_bool_(COMMUNICATION_ERROR, error, last_published_binary_values_,
+                            last_published_binary_ms_, 0)) {
+    return;
+  }
+
+  if (error) {
+    if (!communication_error_active_) {
+      communication_error_active_since_ms_ = now_ms;
+      DAIKIN_WARN(TAG, "Communication error: no complete valid packet cycle for %u ms (threshold=%u ms)",
+                  now_ms - (last_valid_cycle_ms_ != 0 ? last_valid_cycle_ms_ : communication_health_start_ms_),
+                  communication_error_timeout_ms_());
+    }
+  } else if (communication_error_active_) {
+    DAIKIN_WARN(TAG, "Communication recovered after %u ms",
+                communication_error_active_since_ms_ == 0 ? 0 : now_ms - communication_error_active_since_ms_);
+    communication_error_active_since_ms_ = 0;
+  }
+
+  communication_error_active_ = error;
+  defer([sensor = sensor_it->second, error]() { sensor->publish_state(error); });
 }
 
 uint8_t DaikinEkhheComponent::ekhhe_checksum(const std::vector<uint8_t>& data_bytes) {

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -414,6 +414,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   static constexpr uint32_t kSlowPublishRefreshMs = 30 * 60 * 1000;
   static constexpr uint32_t kTimestampRefreshMs = 5 * 60 * 1000;
   static constexpr uint32_t kCycleTimeoutMs = 2000;
+  static constexpr uint32_t kCommunicationErrorMinTimeoutMs = 30 * 1000;
   static constexpr uint32_t kFrameReadTimeoutMs = 120;
   static constexpr size_t kRawFrameMaxLen = 71;
   static constexpr size_t kRawFrameBufferSize = 16;
@@ -489,6 +490,9 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   void start_uart_cycle();
   void process_packet_set();
   bool packet_set_complete();
+  uint32_t communication_error_timeout_ms_() const;
+  void check_communication_error_(uint32_t now_ms);
+  void publish_communication_error_(bool error, uint32_t now_ms);
   uint8_t read_rx_byte_();
   void reset_rx_frame_();
   void consume_uart_byte_(uint8_t byte, uint32_t now_ms);
@@ -975,6 +979,10 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   // Cycle management
   unsigned long last_process_time_ = 0;
   unsigned long update_interval_ = 10000;
+  uint32_t communication_health_start_ms_ = 0;
+  uint32_t last_valid_cycle_ms_ = 0;
+  uint32_t communication_error_active_since_ms_ = 0;
+  bool communication_error_active_ = false;
   uint32_t tx_delay_after_d2_ms_ = kDefaultTxDelayAfterD2Ms;
 };
 

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -24,6 +24,7 @@ static const std::string DIG2_CONFIG             = "dig2_config";
 static const std::string DIG3_CONFIG             = "dig3_config";
 
 static const std::string MASTER_FAULT = "master_fault";
+static const std::string COMMUNICATION_ERROR = "communication_error";
 static const std::string P01_TANK_LOWER_PROBE_FAULT = "p01_tank_lower_probe_fault";
 static const std::string P02_TANK_UPPER_PROBE_FAULT = "p02_tank_upper_probe_fault";
 static const std::string P03_DEFROST_PROBE_FAULT = "p03_defrost_probe_fault";

--- a/components/daikin_ekhhe/daikin_ekhhe_rx.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe_rx.cpp
@@ -356,6 +356,11 @@ void DaikinEkhheComponent::process_packet_set() {
 
   bool has_required = (cycle_packet_types_seen_ & kRequiredPacketMask) == kRequiredPacketMask;
   cycle_publish_allowed_ = has_required;
+  const uint32_t now_ms = millis();
+  if (has_required) {
+    last_valid_cycle_ms_ = now_ms;
+    publish_communication_error_(false, now_ms);
+  }
 
   // Assign stored packets to last known packet values.
   last_dd_packet_ = latest_packets_[DD_PACKET_START_BYTE];
@@ -401,7 +406,7 @@ void DaikinEkhheComponent::process_packet_set() {
 
   // Reset UART cycle.
   processing_updates_ = false;
-  last_process_time_ = millis();
+  last_process_time_ = now_ms;
   if (any_tx_or_ui_sync_active_() || continuous_rx_) {
     start_uart_cycle();
   } else {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,11 +137,18 @@ manual as the primary diagnostic reference when a fault is active.
 `master_fault` is an aggregate OR of the confirmed fault/alarm indicators and
 is intended as the simplest Home Assistant automation trigger.
 
+`communication_error` is a local ESPHome/interface-health indicator. It turns
+on when the component has not received a complete valid bus update within the
+communication timeout window, and turns off again after the next complete valid
+update. It is useful for alerting on disconnected RS485 wiring, stalled bus
+capture, or stale values.
+
 `E04` and `E08` are not exposed yet. They are intentionally omitted because
 they have not been reproducibly observed on this unit in a bus-visible form:
 `E04` may not be present on all manual/hardware variants, and `E08` appears to
 be display-local or otherwise not reported as a confirmed status bit on the
-captured display bus.
+captured display bus. `communication_error` is the recommended ESPHome-side
+health check for that class of issue, but it is not a decoded Daikin `E08`.
 
 ### Target Temperatures
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -136,11 +136,22 @@ that transition instead of hiding it.
 Use `master_fault` when you only need a single alert/automation trigger. It is
 on whenever any confirmed fault/protection/alarm indicator is active.
 
+Use `communication_error` when you want to alert on the ESPHome interface
+itself. It is on when the component has not received a complete valid bus update
+within the communication timeout window. The timeout is the greater of 30
+seconds or three times `update_interval`, so normal non-continuous polling does
+not report false errors between expected reads.
+
+`communication_error` is intentionally separate from `master_fault`: it reports
+stale or missing RS485 data from the ESPHome component's point of view, not a
+confirmed device fault shown by the Daikin display.
+
 `E04` and `E08` are intentionally not included at this time. They are not just
 missing from the entity list; they have not been reproduced with a reliable
 bus-visible status bit. In particular, `E04` may depend on hardware/manual
 variant behavior, and `E08` may be local to the display when communication is
-lost.
+lost. Use `communication_error` for integration-side detection of missing or
+stale bus data.
 
 ## Log Expectations
 
@@ -152,6 +163,7 @@ At `WARN` level, pay attention to:
 - Write applied after more than one attempt: the change worked, but timing or state conditions were not ideal.
 - Restore/profile warnings: the restore was blocked, missing recent source data, missing a stored profile, failed one internal stage, or failed confirmation.
 - Time-band validation warnings: the staged values were rejected before any command was sent.
+- Communication error warnings: the component has stopped receiving complete valid bus updates, or has recovered after such an outage.
 
 At `DEBUG` level, expect more operational timing detail:
 
@@ -176,6 +188,7 @@ For ordinary use, `INFO` is usually enough. Use `DEBUG` while tuning `tx_send_ca
 - Check common ground.
 - Check UART pins and baud settings.
 - Confirm the original display still works.
+- Expose `communication_error` to alert when ESPHome is connected but no longer receiving complete valid bus updates.
 - Temporarily set `continuous_rx: true` if you need to confirm the node can keep up with every bus cycle.
 
 ### Values update but writes fail

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -87,6 +87,8 @@ binary_sensor:
       name: "Electric heater active"
     master_fault:
       name: "Master fault"
+    communication_error:
+      name: "Communication error"
     p01_tank_lower_probe_fault:
       name: "P01: Tank lower probe fault"
     p02_tank_upper_probe_fault:

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -55,6 +55,8 @@ binary_sensor:
   - platform: daikin_ekhhe
     master_fault:
       name: "Fault active"
+    communication_error:
+      name: "Communication error"
     hp_active:
       name: "Heat pump active"
     eh_active:


### PR DESCRIPTION
## Summary

- Add an optional `communication_error` binary sensor that reports when ESPHome stops seeing complete valid bus cycles.
- Keep this separate from `master_fault` and decoded Daikin faults; it represents local interface/bus health, not a device-reported fault.
- Document the sensor and add it to examples plus CI fixture coverage.

## Validation

- `python scripts/check_component_metadata.py`
- `esphome config .github/fixtures/minimal/ci.yaml`
- `esphome config .github/fixtures/production/ci.yaml`
- `git diff --check`
