### PR TITLE
Add vacation runtime sensors

### DIFF
--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -46,6 +46,8 @@ sensor:
       name: "CI Low Water Temperature probe"
     fan_speed_rpm:
       name: "CI Fan Speed RPM"
+    vacation_counter:
+      name: "CI Vacation Counter"
 
 binary_sensor:
   - platform: daikin_ekhhe

--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -48,6 +48,8 @@ sensor:
       name: "CI Fan Speed RPM"
     vacation_day_counter:
       name: "CI Vacation Day Counter"
+    vacation_days_left:
+      name: "CI Vacation Days Left"
 
 binary_sensor:
   - platform: daikin_ekhhe

--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -46,8 +46,8 @@ sensor:
       name: "CI Low Water Temperature probe"
     fan_speed_rpm:
       name: "CI Fan Speed RPM"
-    vacation_counter:
-      name: "CI Vacation Counter"
+    vacation_day_counter:
+      name: "CI Vacation Day Counter"
 
 binary_sensor:
   - platform: daikin_ekhhe

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -9,6 +9,7 @@ G_COMP_GAS_T_PROBE      = "compressor_discharge_gas_temp_probe"
 H_SOLAR_T_PROBE         = "solar_collector_temp_probe"
 I_EEV_STEP              = "eev_opening_step"
 FAN_SPEED_RPM           = "fan_speed_rpm"
+VACATION_COUNTER        = "vacation_counter"
 J_POWER_FW_VERSION      = "power_board_firmware_version"
 L_UI_FW_VERSION         = "ui_firmware_version"
 

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -10,6 +10,7 @@ H_SOLAR_T_PROBE         = "solar_collector_temp_probe"
 I_EEV_STEP              = "eev_opening_step"
 FAN_SPEED_RPM           = "fan_speed_rpm"
 VACATION_DAY_COUNTER    = "vacation_day_counter"
+VACATION_DAYS_LEFT      = "vacation_days_left"
 J_POWER_FW_VERSION      = "power_board_firmware_version"
 L_UI_FW_VERSION         = "ui_firmware_version"
 

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -9,7 +9,7 @@ G_COMP_GAS_T_PROBE      = "compressor_discharge_gas_temp_probe"
 H_SOLAR_T_PROBE         = "solar_collector_temp_probe"
 I_EEV_STEP              = "eev_opening_step"
 FAN_SPEED_RPM           = "fan_speed_rpm"
-VACATION_COUNTER        = "vacation_counter"
+VACATION_DAY_COUNTER    = "vacation_day_counter"
 J_POWER_FW_VERSION      = "power_board_firmware_version"
 L_UI_FW_VERSION         = "ui_firmware_version"
 

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -479,6 +479,11 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   binary_sensor::BinarySensor *heating_demand_ = nullptr;
   binary_sensor::BinarySensor *hp_active_ = nullptr;
   binary_sensor::BinarySensor *eh_active_ = nullptr;
+  bool have_vacation_main_state_ = false;
+  bool have_vacation_day_counter_ = false;
+  uint8_t vacation_operational_mode_ = kOperationalModeAuto;
+  uint8_t vacation_configured_days_ = 0;
+  uint8_t vacation_day_counter_ = 0;
   esphome::time::RealTimeClock *clock = nullptr;
 
   // UART Processing
@@ -494,6 +499,8 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
   uint32_t communication_error_timeout_ms_() const;
   void check_communication_error_(uint32_t now_ms);
   void publish_communication_error_(bool error, uint32_t now_ms);
+  void update_vacation_main_state_from_bus_(const std::vector<uint8_t> &buffer, bool d2_packet);
+  void publish_vacation_days_left_();
   uint8_t read_rx_byte_();
   void reset_rx_frame_();
   void consume_uart_byte_(uint8_t byte, uint32_t now_ms);

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -217,7 +217,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
     DD_PACKET_H_IDX     = 14,
     DD_PACKET_I_IDX     = 17,
     DD_PACKET_DIG_IDX     = 21,
-    DD_PACKET_VACATION_COUNTER_IDX = 24,
+    DD_PACKET_VACATION_DAY_COUNTER_IDX = 24,
     DD_PACKET_FAN_RPM_IDX = 26,
     DD_PACKET_J_FW_IDX    = 39,
     DD_PACKET_END       = 40,

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -217,6 +217,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
     DD_PACKET_H_IDX     = 14,
     DD_PACKET_I_IDX     = 17,
     DD_PACKET_DIG_IDX     = 21,
+    DD_PACKET_VACATION_COUNTER_IDX = 24,
     DD_PACKET_FAN_RPM_IDX = 26,
     DD_PACKET_J_FW_IDX    = 39,
     DD_PACKET_END       = 40,

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -16,6 +16,7 @@ static const std::string G_COMP_GAS_T_PROBE      = "compressor_discharge_gas_tem
 static const std::string H_SOLAR_T_PROBE         = "solar_collector_temp_probe";
 static const std::string I_EEV_STEP              = "eev_opening_step";
 static const std::string FAN_SPEED_RPM           = "fan_speed_rpm";
+static const std::string VACATION_COUNTER        = "vacation_counter";
 static const std::string J_POWER_FW_VERSION      = "power_board_firmware_version";
 static const std::string L_UI_FW_VERSION         = "ui_firmware_version";
 

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -17,6 +17,7 @@ static const std::string H_SOLAR_T_PROBE         = "solar_collector_temp_probe";
 static const std::string I_EEV_STEP              = "eev_opening_step";
 static const std::string FAN_SPEED_RPM           = "fan_speed_rpm";
 static const std::string VACATION_DAY_COUNTER    = "vacation_day_counter";
+static const std::string VACATION_DAYS_LEFT      = "vacation_days_left";
 static const std::string J_POWER_FW_VERSION      = "power_board_firmware_version";
 static const std::string L_UI_FW_VERSION         = "ui_firmware_version";
 

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -16,7 +16,7 @@ static const std::string G_COMP_GAS_T_PROBE      = "compressor_discharge_gas_tem
 static const std::string H_SOLAR_T_PROBE         = "solar_collector_temp_probe";
 static const std::string I_EEV_STEP              = "eev_opening_step";
 static const std::string FAN_SPEED_RPM           = "fan_speed_rpm";
-static const std::string VACATION_COUNTER        = "vacation_counter";
+static const std::string VACATION_DAY_COUNTER    = "vacation_day_counter";
 static const std::string J_POWER_FW_VERSION      = "power_board_firmware_version";
 static const std::string L_UI_FW_VERSION         = "ui_firmware_version";
 

--- a/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
@@ -52,6 +52,8 @@ void DaikinEkhheComponent::update_dd_b1_bit_sensors_() {
 void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
   const float lower_water_temperature = static_cast<int8_t>(buffer[DD_PACKET_A_IDX]);
   const float upper_water_temperature = static_cast<int8_t>(buffer[DD_PACKET_B_IDX]);
+  this->vacation_day_counter_ = buffer[DD_PACKET_VACATION_DAY_COUNTER_IDX];
+  this->have_vacation_day_counter_ = true;
 
 #if defined(USE_WATER_HEATER)
   update_water_heater_temperature_cache_(lower_water_temperature, upper_water_temperature);
@@ -68,13 +70,14 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
       {G_COMP_GAS_T_PROBE,     buffer[DD_PACKET_G_IDX]},
       {H_SOLAR_T_PROBE,        buffer[DD_PACKET_H_IDX]},
       {I_EEV_STEP,             (float)((buffer[DD_PACKET_I_IDX] << 8) | buffer[DD_PACKET_I_IDX + 1])},
-      {VACATION_DAY_COUNTER,   static_cast<float>(buffer[DD_PACKET_VACATION_DAY_COUNTER_IDX])},
+      {VACATION_DAY_COUNTER,   static_cast<float>(this->vacation_day_counter_)},
       {FAN_SPEED_RPM,          (float)((buffer[DD_PACKET_FAN_RPM_IDX] << 8) | buffer[DD_PACKET_FAN_RPM_IDX + 1])},
   };
 
   for (const auto &entry : sensor_values) {
     set_sensor_value(entry.first, entry.second);
   }
+  publish_vacation_days_left_();
 
   set_text_sensor_value_(J_POWER_FW_VERSION, "U" + std::to_string(buffer[DD_PACKET_J_FW_IDX]));
 
@@ -124,6 +127,40 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
   return;
 }
 
+void DaikinEkhheComponent::update_vacation_main_state_from_bus_(const std::vector<uint8_t> &buffer,
+                                                                bool d2_packet) {
+  const uint8_t mode_idx = d2_packet ? static_cast<uint8_t>(D2_PACKET_MODE_IDX)
+                                     : static_cast<uint8_t>(CC_PACKET_MODE_IDX);
+  const uint8_t vacation_days_idx = d2_packet ? static_cast<uint8_t>(D2_PACKET_VAC_DAYS)
+                                              : static_cast<uint8_t>(CC_PACKET_VAC_DAYS);
+  if (buffer.size() <= mode_idx || buffer.size() <= vacation_days_idx) {
+    return;
+  }
+
+  this->vacation_operational_mode_ = buffer[mode_idx];
+  this->vacation_configured_days_ = buffer[vacation_days_idx];
+  this->have_vacation_main_state_ = true;
+  publish_vacation_days_left_();
+}
+
+void DaikinEkhheComponent::publish_vacation_days_left_() {
+  if (!this->have_vacation_main_state_) {
+    return;
+  }
+
+  float days_left = 0.0f;
+  if (this->vacation_operational_mode_ == kOperationalModeVacation) {
+    if (!this->have_vacation_day_counter_) {
+      return;
+    }
+    if (this->vacation_configured_days_ > this->vacation_day_counter_) {
+      days_left = static_cast<float>(this->vacation_configured_days_ - this->vacation_day_counter_);
+    }
+  }
+
+  set_sensor_value(VACATION_DAYS_LEFT, days_left);
+}
+
 void DaikinEkhheComponent::update_time_band_state_from_bus_(const std::vector<uint8_t> &buffer,
                                                             bool d2_packet, bool force) {
   const uint8_t flag_idx = d2_packet ? static_cast<uint8_t>(D2_PACKET_TIME_BAND_FLAG_IDX)
@@ -163,6 +200,7 @@ void DaikinEkhheComponent::update_time_band_state_from_bus_(const std::vector<ui
 }
 
 void DaikinEkhheComponent::parse_d2_packet(std::vector<uint8_t> buffer) {
+  update_vacation_main_state_from_bus_(buffer, true);
   update_time_band_state_from_bus_(buffer, true);
 
   // update numbers
@@ -412,6 +450,7 @@ void DaikinEkhheComponent::parse_cc_packet(std::vector<uint8_t> buffer) {
                                 time_band_sync.mode);
   const bool pending_profile_active = profile_restore_tx_active_();
 
+  update_vacation_main_state_from_bus_(buffer, false);
   update_time_band_state_from_bus_(buffer, false, time_band_cc_sync_matched);
 
   for (const auto &entry : NUMBER_FIELD_SPECS) {

--- a/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
@@ -68,6 +68,7 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
       {G_COMP_GAS_T_PROBE,     buffer[DD_PACKET_G_IDX]},
       {H_SOLAR_T_PROBE,        buffer[DD_PACKET_H_IDX]},
       {I_EEV_STEP,             (float)((buffer[DD_PACKET_I_IDX] << 8) | buffer[DD_PACKET_I_IDX + 1])},
+      {VACATION_COUNTER,       static_cast<float>(buffer[DD_PACKET_VACATION_COUNTER_IDX])},
       {FAN_SPEED_RPM,          (float)((buffer[DD_PACKET_FAN_RPM_IDX] << 8) | buffer[DD_PACKET_FAN_RPM_IDX + 1])},
   };
 

--- a/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
@@ -68,7 +68,7 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
       {G_COMP_GAS_T_PROBE,     buffer[DD_PACKET_G_IDX]},
       {H_SOLAR_T_PROBE,        buffer[DD_PACKET_H_IDX]},
       {I_EEV_STEP,             (float)((buffer[DD_PACKET_I_IDX] << 8) | buffer[DD_PACKET_I_IDX + 1])},
-      {VACATION_COUNTER,       static_cast<float>(buffer[DD_PACKET_VACATION_COUNTER_IDX])},
+      {VACATION_DAY_COUNTER,   static_cast<float>(buffer[DD_PACKET_VACATION_DAY_COUNTER_IDX])},
       {FAN_SPEED_RPM,          (float)((buffer[DD_PACKET_FAN_RPM_IDX] << 8) | buffer[DD_PACKET_FAN_RPM_IDX + 1])},
   };
 

--- a/components/daikin_ekhhe/sensor.py
+++ b/components/daikin_ekhhe/sensor.py
@@ -62,6 +62,12 @@ SENSOR_SPECS = [
         state_class=STATE_CLASS_MEASUREMENT,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    SensorSchemaSpec(
+        VACATION_DAYS_LEFT,
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
 ]
 
 TYPES = [spec.key for spec in SENSOR_SPECS]

--- a/components/daikin_ekhhe/sensor.py
+++ b/components/daikin_ekhhe/sensor.py
@@ -55,6 +55,13 @@ SENSOR_SPECS = [
         state_class=STATE_CLASS_MEASUREMENT,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    SensorSchemaSpec(
+        VACATION_COUNTER,
+        unit_of_measurement=UNIT_EMPTY,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
 ]
 
 TYPES = [spec.key for spec in SENSOR_SPECS]

--- a/components/daikin_ekhhe/sensor.py
+++ b/components/daikin_ekhhe/sensor.py
@@ -56,7 +56,7 @@ SENSOR_SPECS = [
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
     SensorSchemaSpec(
-        VACATION_COUNTER,
+        VACATION_DAY_COUNTER,
         unit_of_measurement=UNIT_EMPTY,
         accuracy_decimals=0,
         state_class=STATE_CLASS_MEASUREMENT,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,12 @@ Useful read-only values for monitoring the heat pump:
 - `solar_collector_temp_probe`
 - `eev_opening_step`
 - `fan_speed_rpm`
+- `vacation_counter`
+
+`vacation_counter` is an observed runtime counter that increments while the
+device is in Vacation mode and resets when Vacation mode ends. It is exposed as
+a diagnostic sensor because the exact manufacturer semantics are still being
+validated.
 
 ### Basic Operation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,12 +62,12 @@ Useful read-only values for monitoring the heat pump:
 - `solar_collector_temp_probe`
 - `eev_opening_step`
 - `fan_speed_rpm`
-- `vacation_counter`
+- `vacation_day_counter`
 
-`vacation_counter` is an observed runtime counter that increments while the
-device is in Vacation mode and resets when Vacation mode ends. It is exposed as
-a diagnostic sensor because the exact manufacturer semantics are still being
-validated.
+`vacation_day_counter` is an observed runtime counter that increments while
+the device is in Vacation mode and resets when Vacation mode ends. It is
+exposed as a diagnostic sensor because the exact manufacturer semantics and
+off-by-one behavior are still being validated.
 
 ### Basic Operation
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,11 +63,16 @@ Useful read-only values for monitoring the heat pump:
 - `eev_opening_step`
 - `fan_speed_rpm`
 - `vacation_day_counter`
+- `vacation_days_left`
 
 `vacation_day_counter` is an observed runtime counter that increments while
 the device is in Vacation mode and resets when Vacation mode ends. It is
 exposed as a diagnostic sensor because the exact manufacturer semantics and
 off-by-one behavior are still being validated.
+
+`vacation_days_left` is derived from bus readback while Vacation mode is active
+using `max(vacation_days - vacation_day_counter, 0)`. It publishes `0` outside
+Vacation mode.
 
 ### Basic Operation
 

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -70,6 +70,8 @@ sensor:
       name: "I: EEV opening step"
     fan_speed_rpm:
       name: "Fan speed RPM"
+    vacation_counter:
+      name: "Vacation counter"
 
 binary_sensor:
   - platform: daikin_ekhhe

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -70,8 +70,8 @@ sensor:
       name: "I: EEV opening step"
     fan_speed_rpm:
       name: "Fan speed RPM"
-    vacation_counter:
-      name: "Vacation counter"
+    vacation_day_counter:
+      name: "Vacation day counter"
 
 binary_sensor:
   - platform: daikin_ekhhe

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -72,6 +72,8 @@ sensor:
       name: "Fan speed RPM"
     vacation_day_counter:
       name: "Vacation day counter"
+    vacation_days_left:
+      name: "Vacation days left"
 
 binary_sensor:
   - platform: daikin_ekhhe

--- a/scripts/check_component_metadata.py
+++ b/scripts/check_component_metadata.py
@@ -40,7 +40,7 @@ PLATFORM_SOURCE_PATHS = [
 ]
 
 REQUIRED_PRODUCTION_FIXTURE_KEYS = {
-    "sensor": ["A_LOW_WAT_T_PROBE", "FAN_SPEED_RPM", "VACATION_DAY_COUNTER"],
+    "sensor": ["A_LOW_WAT_T_PROBE", "FAN_SPEED_RPM", "VACATION_DAY_COUNTER", "VACATION_DAYS_LEFT"],
     "runtime binary sensor": ["HEATING_DEMAND", "HP_ACTIVE", "EH_ACTIVE"],
     "fault binary sensor": ["MASTER_FAULT", "P01_TANK_LOWER_PROBE_FAULT"],
     "main number": ["P1_LOW_WAT_PROBE_HYST"],

--- a/scripts/check_component_metadata.py
+++ b/scripts/check_component_metadata.py
@@ -40,7 +40,7 @@ PLATFORM_SOURCE_PATHS = [
 ]
 
 REQUIRED_PRODUCTION_FIXTURE_KEYS = {
-    "sensor": ["A_LOW_WAT_T_PROBE", "FAN_SPEED_RPM"],
+    "sensor": ["A_LOW_WAT_T_PROBE", "FAN_SPEED_RPM", "VACATION_COUNTER"],
     "runtime binary sensor": ["HEATING_DEMAND", "HP_ACTIVE", "EH_ACTIVE"],
     "fault binary sensor": ["MASTER_FAULT", "P01_TANK_LOWER_PROBE_FAULT"],
     "main number": ["P1_LOW_WAT_PROBE_HYST"],

--- a/scripts/check_component_metadata.py
+++ b/scripts/check_component_metadata.py
@@ -40,7 +40,7 @@ PLATFORM_SOURCE_PATHS = [
 ]
 
 REQUIRED_PRODUCTION_FIXTURE_KEYS = {
-    "sensor": ["A_LOW_WAT_T_PROBE", "FAN_SPEED_RPM", "VACATION_COUNTER"],
+    "sensor": ["A_LOW_WAT_T_PROBE", "FAN_SPEED_RPM", "VACATION_DAY_COUNTER"],
     "runtime binary sensor": ["HEATING_DEMAND", "HP_ACTIVE", "EH_ACTIVE"],
     "fault binary sensor": ["MASTER_FAULT", "P01_TANK_LOWER_PROBE_FAULT"],
     "main number": ["P1_LOW_WAT_PROBE_HYST"],


### PR DESCRIPTION
## Summary

Adds two optional Vacation-mode runtime sensors:

- `vacation_day_counter`: the raw observed DD runtime counter that increments while Vacation mode is active and resets when Vacation mode ends.
- `vacation_days_left`: a derived user-facing sensor calculated from bus readback as `max(vacation_days - vacation_day_counter, 0)` while Vacation mode is active, and `0` outside Vacation mode.

The raw counter remains diagnostic because the exact manufacturer/off-by-one semantics are still being validated. The derived days-left sensor is intended to be easier to use in Home Assistant dashboards and automations.

## User impact

Users can opt in with:

```yaml
sensor:
  - platform: daikin_ekhhe
    vacation_day_counter:
      name: "Vacation day counter"
    vacation_days_left:
      name: "Vacation days left"
```

Both sensors are read-only and do not change any write behavior.

## Validation

- `python3 scripts/check_component_metadata.py`
- `git diff --check`
- `esphome config .github/fixtures/minimal/ci.yaml`
- `esphome config .github/fixtures/production/ci.yaml`
- `esphome config .github/fixtures/water_heater/ci.yaml`
- `esphome compile .github/fixtures/production/ci.yaml`