### PR TITLE
Add legionella cycle activity sensor

### DIFF
--- a/.github/fixtures/production/ci.yaml
+++ b/.github/fixtures/production/ci.yaml
@@ -65,6 +65,8 @@ binary_sensor:
       name: "CI Master Fault"
     communication_error:
       name: "CI Communication Error"
+    legionella_cycle_active:
+      name: "CI Legionella Cycle Active"
     p01_tank_lower_probe_fault:
       name: "CI P01 Tank Lower Probe Fault"
     p02_tank_upper_probe_fault:

--- a/components/daikin_ekhhe/binary_sensor.py
+++ b/components/daikin_ekhhe/binary_sensor.py
@@ -29,6 +29,10 @@ BINARY_SENSOR_SPECS = [
         device_class=DEVICE_CLASS_PROBLEM,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    BinarySensorSchemaSpec(
+        LEGIONELLA_CYCLE_ACTIVE,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
     *[
         BinarySensorSchemaSpec(key, entity_category=ENTITY_CATEGORY_DIAGNOSTIC)
         for key in [

--- a/components/daikin_ekhhe/const.py
+++ b/components/daikin_ekhhe/const.py
@@ -20,6 +20,7 @@ DIG3_CONFIG             = "dig3_config"
 
 MASTER_FAULT = "master_fault"
 COMMUNICATION_ERROR = "communication_error"
+LEGIONELLA_CYCLE_ACTIVE = "legionella_cycle_active"
 P01_TANK_LOWER_PROBE_FAULT = "p01_tank_lower_probe_fault"
 P02_TANK_UPPER_PROBE_FAULT = "p02_tank_upper_probe_fault"
 P03_DEFROST_PROBE_FAULT = "p03_defrost_probe_fault"

--- a/components/daikin_ekhhe/daikin_ekhhe.h
+++ b/components/daikin_ekhhe/daikin_ekhhe.h
@@ -216,6 +216,7 @@ class DaikinEkhheComponent : public Component, public uart::UARTDevice {
     DD_PACKET_G_IDX     = 13,
     DD_PACKET_H_IDX     = 14,
     DD_PACKET_I_IDX     = 17,
+    DD_PACKET_LEGIONELLA_STATUS_IDX = 19,
     DD_PACKET_DIG_IDX     = 21,
     DD_PACKET_VACATION_DAY_COUNTER_IDX = 24,
     DD_PACKET_FAN_RPM_IDX = 26,

--- a/components/daikin_ekhhe/daikin_ekhhe_const.h
+++ b/components/daikin_ekhhe/daikin_ekhhe_const.h
@@ -27,6 +27,7 @@ static const std::string DIG3_CONFIG             = "dig3_config";
 
 static const std::string MASTER_FAULT = "master_fault";
 static const std::string COMMUNICATION_ERROR = "communication_error";
+static const std::string LEGIONELLA_CYCLE_ACTIVE = "legionella_cycle_active";
 static const std::string P01_TANK_LOWER_PROBE_FAULT = "p01_tank_lower_probe_fault";
 static const std::string P02_TANK_UPPER_PROBE_FAULT = "p02_tank_upper_probe_fault";
 static const std::string P03_DEFROST_PROBE_FAULT = "p03_defrost_probe_fault";

--- a/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
+++ b/components/daikin_ekhhe/daikin_ekhhe_parse.cpp
@@ -94,6 +94,7 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
   const bool e02_solar_recirculation_alarm = (buffer[DD_PACKET_ALARM_IDX] & 0x02) != 0;
   const bool e03_electronic_fan_fault = (buffer[DD_PACKET_ALARM2_IDX] & 0x08) != 0;
   const bool pa_heat_pump_temp_unsuitable_alarm = (buffer[DD_PACKET_ALARM_IDX] & 0x10) != 0;
+  const bool legionella_cycle_active = (buffer[DD_PACKET_LEGIONELLA_STATUS_IDX] & 0x02) != 0;
   const bool master_fault = p01_tank_lower_probe_fault || p02_tank_upper_probe_fault || p03_defrost_probe_fault ||
                             p04_inlet_air_probe_fault || p05_evaporator_inlet_probe_fault ||
                             p06_evaporator_outlet_probe_fault || p07_compressor_flow_probe_fault ||
@@ -106,6 +107,7 @@ void DaikinEkhheComponent::parse_dd_packet(std::vector<uint8_t> buffer) {
       {DIG2_CONFIG, (bool)(buffer[DD_PACKET_DIG_IDX] & 0x02)},
       {DIG3_CONFIG, (bool)(buffer[DD_PACKET_DIG_IDX] & 0x04)},
       {MASTER_FAULT, master_fault},
+      {LEGIONELLA_CYCLE_ACTIVE, legionella_cycle_active},
       {P01_TANK_LOWER_PROBE_FAULT, p01_tank_lower_probe_fault},
       {P02_TANK_UPPER_PROBE_FAULT, p02_tank_upper_probe_fault},
       {P03_DEFROST_PROBE_FAULT, p03_defrost_probe_fault},

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,10 +91,6 @@ Common day-to-day controls and state indicators:
 
 `silent_mode` can be enabled only while the unit is in Auto, Eco, or Boost mode. Disabling it is allowed from any mode so the setting can be cleared safely if the operating mode changes.
 
-`legionella_cycle_active` reports the complete scheduled anti-legionella cycle,
-including its final temperature-hold period. It is distinct from `eh_active`,
-which reports only whether the electric heating element is energized.
-
 The optional native water heater entity provides a Home Assistant DHW card on
 top of the same readback and write logic used by the detailed entities:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,9 +86,14 @@ Common day-to-day controls and state indicators:
 - `hp_active`
 - `eh_active`
 - `heating_demand`
+- `legionella_cycle_active`
 - `vacation_days`
 
 `silent_mode` can be enabled only while the unit is in Auto, Eco, or Boost mode. Disabling it is allowed from any mode so the setting can be cleared safely if the operating mode changes.
+
+`legionella_cycle_active` reports the complete scheduled anti-legionella cycle,
+including its final temperature-hold period. It is distinct from `eh_active`,
+which reports only whether the electric heating element is energized.
 
 The optional native water heater entity provides a Home Assistant DHW card on
 top of the same readback and write logic used by the detailed entities:

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -42,6 +42,11 @@ The currently useful mental model is to group packets by ownership and purpose. 
 
 The implementation uses these families when selecting the packet to send and the packet to trust for confirmation.
 
+Known `DD` runtime indicators include heat demand, heat-pump activity,
+electric-heater activity, and anti-legionella cycle activity. The latter is
+reported by `DD[19]` bit 1. It remains asserted during the cycle's final hold
+period after the electric-heater-active bit clears.
+
 ## Observed Idle Cycle
 
 With continuous RX enabled, the stable cycle is roughly 1.49 to 1.50 seconds. A commonly observed order is:

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -42,11 +42,6 @@ The currently useful mental model is to group packets by ownership and purpose. 
 
 The implementation uses these families when selecting the packet to send and the packet to trust for confirmation.
 
-Known `DD` runtime indicators include heat demand, heat-pump activity,
-electric-heater activity, and anti-legionella cycle activity. The latter is
-reported by `DD[19]` bit 1. It remains asserted during the cycle's final hold
-period after the electric-heater-active bit clears.
-
 ## Observed Idle Cycle
 
 With continuous RX enabled, the stable cycle is roughly 1.49 to 1.50 seconds. A commonly observed order is:

--- a/examples/full.yaml
+++ b/examples/full.yaml
@@ -93,6 +93,8 @@ binary_sensor:
       name: "Master fault"
     communication_error:
       name: "Communication error"
+    legionella_cycle_active:
+      name: "Legionella Cycle Active"
     p01_tank_lower_probe_fault:
       name: "P01: Tank lower probe fault"
     p02_tank_upper_probe_fault:

--- a/scripts/check_component_metadata.py
+++ b/scripts/check_component_metadata.py
@@ -41,7 +41,12 @@ PLATFORM_SOURCE_PATHS = [
 
 REQUIRED_PRODUCTION_FIXTURE_KEYS = {
     "sensor": ["A_LOW_WAT_T_PROBE", "FAN_SPEED_RPM", "VACATION_DAY_COUNTER", "VACATION_DAYS_LEFT"],
-    "runtime binary sensor": ["HEATING_DEMAND", "HP_ACTIVE", "EH_ACTIVE"],
+    "runtime binary sensor": [
+        "HEATING_DEMAND",
+        "HP_ACTIVE",
+        "EH_ACTIVE",
+        "LEGIONELLA_CYCLE_ACTIVE",
+    ],
     "fault binary sensor": ["MASTER_FAULT", "P01_TANK_LOWER_PROBE_FAULT"],
     "main number": ["P1_LOW_WAT_PROBE_HYST"],
     "extended number": ["P53_EVA_FAN_DEFR_SPEED", "P72_EC_FAN_REG_GAIN"],


### PR DESCRIPTION
## Summary

- add the optional `legionella_cycle_active` diagnostic binary sensor
- decode cycle activity from `DD[19]` bit 1 independently of electric-heater activity
- document the complete cycle/hold semantics and add the entity to the full example
- cover the entity in the production CI fixture and metadata validation

## Validation

- `python3 scripts/check_component_metadata.py`
- ESPHome 2026.5.3 configuration validation for production fixture
- ESPHome 2026.5.3 configuration validation for minimal fixture (entity omitted)